### PR TITLE
Fixing Python 2 compat string formatting

### DIFF
--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -561,7 +561,7 @@ class ParameterSet(object):
     def check_params(self):
         NZ = driver.get_nz()
         assert self._params["zmet"] in range(1, NZ + 1), \
-            "zmet={} out of range [1, {0}]".format(self._params["zmet"], NZ)
+            "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
         assert self._params["dust_type"] in range(4), \
             "dust_type={} out of range [0, 3]".format(
                 self._params["dust_type"])


### PR DESCRIPTION
Why did you make stupid?
