### PR TITLE
Continuous metallicities for compsp

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -29,7 +29,7 @@ except KeyError:
     raise ImportError("You need to have the SPS_HOME environment variable")
 
 # Check the SVN revision number.
-ACCEPTED_FSPS_REVISIONS = [158, 160, 166, 168]
+ACCEPTED_FSPS_REVISIONS = [158, 160, 166, 168, 170]
 cmd = ["svnversion", ev]
 stat, out = run_command(" ".join(cmd))
 fsps_vers = int(re.match("^([0-9])+", out[0]).group(0))

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -243,6 +243,34 @@ contains
   end subroutine
 
 
+  subroutine compute_zdep(ns,n_age)
+
+    ! Compute the full CSP (and the SSPs if they aren't already cached).
+    ! After interpolation in metallicity
+
+    implicit none
+    integer, intent(in) :: ns,n_age
+    double precision, dimension(ns,n_age) :: spec
+    double precision, dimension(n_age) :: mass,lbol
+    integer :: zlo,zmet
+    double precision :: dz,zpos
+    character(100) :: outfile
+
+    ! Find the bracketing metallicity indices and generate ssps if
+    ! necessary, then interpolate.
+    zpos = pset%logzsol
+    zlo = max(min(locate(log10(zlegend/0.0190),zpos),nz-1),1)
+    do zmet=zlo,zlo+1
+       if (has_ssp(zmet) .eq. 0) then
+          call ssp(zmet)
+       endif
+    enddo
+    call ztinterp(zpos,spec,lbol,mass)
+    call compsp(0,1,outfile,mass,lbol,spec,pset,ocompsp)
+
+  end subroutine
+
+  
   subroutine get_spec(ns,n_age,spec_out)
 
     ! Get the grid of spectra for the computed CSP at all ages.

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -809,9 +809,9 @@ class ParameterSet(object):
         self.iteritems = self._params.iteritems
 
     def check_params(self):
-        NZ = driver.get_nz()
-        assert self._params["zmet"] in range(1, NZ + 1), \
-            "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
+        #NZ = driver.get_nz()
+        #assert self._params["zmet"] in range(1, NZ + 1), \
+        #    "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
         assert self._params["dust_type"] in range(4), \
             "dust_type={0} out of range [0, 3]".format(
                 self._params["dust_type"])

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -809,9 +809,9 @@ class ParameterSet(object):
         self.iteritems = self._params.iteritems
 
     def check_params(self):
-        #NZ = driver.get_nz()
-        #assert self._params["zmet"] in range(1, NZ + 1), \
-        #    "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
+        NZ = driver.get_nz()
+        assert self._params["zmet"] in range(1, NZ + 1), \
+            "zmet={0} out of range [1, {1}]".format(self._params["zmet"], NZ)
         assert self._params["dust_type"] in range(4), \
             "dust_type={0} out of range [0, 3]".format(
                 self._params["dust_type"])

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -33,6 +33,13 @@ class StellarPopulation(object):
         A switch that sets the zero points of the magnitude system: ``True``
         uses Vega magnitudes versus AB magnitudes.
 
+    :param zcontinuous: (default: False)
+        A switch that controls whether interpolation in metallicity is
+        performed before computing composite models.  If ``True`` then
+        the SSPs are interpolated to the value of ``logzsol`` before
+        the spectra and magnitudes are computed, and the value of
+        ``zmet`` is ignored.
+        
     :param redshift_colors: (default: False)
 
         * ``False``: Magnitudes are computed at a fixed redshift specified
@@ -158,7 +165,8 @@ class StellarPopulation(object):
         i.e. where ``t > dust_tesc`` (for details, see Conroy et al. 2009a).
 
     :param logzsol: (default: -0.2)
-        Undocumented.
+        Parameter describing the metallicity, given in units of
+        log(Z/Z_sun).  Only used if ``zontinuous=True``.
 
     :param zred: (default: 0.0)
         Redshift. If this value is non-zero and if ``redshift_colors=1``,
@@ -261,7 +269,7 @@ class StellarPopulation(object):
         Truncate the IMF above this value.
 
     :param zmet: (default: 1)
-        The metallicity is specified as an integer ranging between 1 and 22.
+        The metallicity is specified as an integer ranging between 1 and nz.
 
     :param sfh: (default: 0)
         Defines the type of star formation history, normalized such that one
@@ -415,7 +423,6 @@ class StellarPopulation(object):
         self._zlegend = None
         self._ssp_ages = None
         self._stats = None
-        
         
     def _update_params(self):
         if self.params.dirtiness == 2:

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -324,7 +324,8 @@ class StellarPopulation(object):
     def __init__(self, compute_vega_mags=True, redshift_colors=False,
                  smooth_velocity=True, add_stellar_remnants=True,
                  add_dust_emission=True, add_agb_dust_model=False,
-                 add_neb_emission=False, tpagb_norm_type=1, **kwargs):
+                 add_neb_emission=False, tpagb_norm_type=1,
+                 zcontinuous=False,**kwargs):
 
         # Set up the parameters to their default values.
         self.params = ParameterSet(
@@ -406,13 +407,16 @@ class StellarPopulation(object):
             assert add_dust_emission == bool(ade)
             assert add_agb_dust_model == bool(agbd)
             assert tpagb_norm_type == agbn
+
+        self._zcontinuous = zcontinuous
             
         # Caching.
         self._wavelengths = None
         self._zlegend = None
         self._ssp_ages = None
         self._stats = None
-
+        
+        
     def _update_params(self):
         if self.params.dirtiness == 2:
             driver.set_ssp_params(*[self.params[k]
@@ -424,7 +428,12 @@ class StellarPopulation(object):
 
     def _compute_csp(self):
         self._update_params()
-        driver.compute()
+        if self._zcontinuous:
+            NSPEC = driver.get_nspec()
+            NTFULL = driver.get_ntfull()
+            driver.compute_zdep(NSPEC, NTFULL)
+        else:
+            driver.compute()
         self._stats = None
 
     def get_spectrum(self, zmet=None, tage=0.0, peraa=False):


### PR DESCRIPTION
This pull request introduces the ability to obtain models for a continuous range of metallicities.  This ability is enabled by setting a flag at initialization (``zcontinuous=True``). Setting this flag causes the SSPs to be interpolated in metallicity to the value of the parameter ``logzsol`` before being passed to compsp for get_spectrum() and get_mags().  Ignoring this flag leaves the behavior the same as before, i.e. metallicities are specified by an integer index through the ``zmet`` parameter.