### PR TITLE
Updating and moving parameters around

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -29,7 +29,7 @@ except KeyError:
     raise ImportError("You need to have the SPS_HOME environment variable")
 
 # Check the SVN revision number.
-ACCEPTED_FSPS_REVISIONS = [158, 160, 166, 168, 170]
+ACCEPTED_FSPS_REVISIONS = [172, 173, 174, 175, 177, 178, 181, 183, 185]
 cmd = ["svnversion", ev]
 stat, out = run_command(" ".join(cmd))
 fsps_vers = int(re.match("^([0-9])+", out[0]).group(0))

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -17,47 +17,40 @@ module driver
 
 contains
 
-  subroutine setup(compute_vega_mags0,redshift_colors0,smooth_velocity0,&
-                   add_stellar_remnants0,add_neb_emission0, &
-                   add_dust_emission0,add_agb_dust_model0, &
-                   tpagb_norm_type0)
+  subroutine setup(compute_vega_mags0)
 
     ! Load all the data files/templates into memory.
 
     implicit none
 
-    integer, intent(in) :: compute_vega_mags0, redshift_colors0, &
-         smooth_velocity0,add_stellar_remnants0,add_neb_emission0, &
-         add_dust_emission0,add_agb_dust_model0,tpagb_norm_type0
+    integer, intent(in) :: compute_vega_mags0
          
 
     compute_vega_mags = compute_vega_mags0
-    redshift_colors = redshift_colors0
-    smooth_velocity = smooth_velocity0
-    add_dust_emission = add_dust_emission0
-    add_agb_dust_model = add_agb_dust_model0
-    add_neb_emission = add_neb_emission0
-    add_stellar_remnants = add_stellar_remnants0
-    tpagb_norm_type = tpagb_norm_type0
     call sps_setup(-1)
     is_setup = 1
 
   end subroutine
 
   subroutine set_ssp_params(imf_type0,imf1,imf2,imf3,vdmc,mdave,dell,&
-                            delt,sbss,fbhb,pagb,agb_dust,redgb,&
-                            masscut,fcstar,evtype)
-
+                            delt,sbss,fbhb,pagb,add_stellar_remnants0,&
+                            tpagb_norm_type0,add_agb_dust_model0,agb_dust,&
+                            redgb,masscut,fcstar,evtype)
+ 
     ! Set the parameters that affect the SSP computation.
 
     implicit none
 
-    integer, intent(in) :: imf_type0
+    integer, intent(in) :: imf_type0,add_stellar_remnants0,tpagb_norm_type0,&
+                           add_agb_dust_model0
     double precision, intent(in) :: imf1,imf2,imf3,vdmc,mdave,dell,&
                                     delt,sbss,fbhb,pagb,agb_dust,&
                                     redgb,masscut,fcstar,evtype
 
     imf_type=imf_type0
+    add_stellar_remnants=add_stellar_remnants0
+    tpagb_norm_type=tpagb_norm_type0
+    add_agb_dust_model=add_agb_dust_model0
     pset%imf1=imf1
     pset%imf2=imf2
     pset%imf3=imf3
@@ -78,20 +71,26 @@ contains
 
   end subroutine
 
-  subroutine set_csp_params(dust_type0,zmet,sfh,wgp1,wgp2,wgp3,tau,&
+  subroutine set_csp_params(smooth_velocity0,vactoair_flag0,redshift_colors0,&
+                            dust_type0,add_dust_emission0,add_neb_emission0,&
+                            add_neb_continuum0,add_igm_absorption0,&
+                            zmet,sfh,wgp1,wgp2,wgp3,tau,&
                             const,tage,fburst,tburst,dust1,dust2,&
                             logzsol,zred,pmetals,dust_clumps,frac_nodust,&
                             dust_index,dust_tesc,frac_obrun,uvb,mwr,&
                             dust1_index,sf_start,sf_trunc,sf_theta,&
                             duste_gamma,duste_umin,duste_qpah,&
                             sigma_smooth,min_wave_smooth,&
-                            max_wave_smooth)
+                            max_wave_smooth,gas_logu,gas_logz,igm_factor)
 
     ! Set all the parameters that don't affect the SSP computation.
 
     implicit none
-
-    integer, intent(in) :: dust_type0,zmet,sfh,wgp1,wgp2,wgp3
+    
+    integer, intent(in) :: smooth_velocity0,vactoair_flag0,redshift_colors0,&
+                           dust_type0,add_dust_emission0,add_neb_emission0,&
+                           add_neb_continuum0,add_igm_absorption0,&
+                           zmet,sfh,wgp1,wgp2,wgp3
     double precision, intent(in) :: tau,&
                             const,tage,fburst,tburst,dust1,dust2,&
                             logzsol,zred,pmetals,dust_clumps,frac_nodust,&
@@ -99,7 +98,16 @@ contains
                             dust1_index,sf_start,sf_trunc,sf_theta,&
                             duste_gamma,duste_umin,duste_qpah,&
                             sigma_smooth,min_wave_smooth,&
-                            max_wave_smooth
+                            max_wave_smooth,gas_logu,gas_logz,igm_factor
+
+    smooth_velocity=smooth_velocity0
+    vactoair_flag=vactoair_flag0
+    redshift_colors=redshift_colors0
+    dust_type=dust_type0
+    add_dust_emission=add_dust_emission0
+    add_neb_emission=add_neb_emission0
+    add_neb_continuum=add_neb_continuum0
+    add_igm_absorption=add_igm_absorption0
 
     pset%zmet=zmet
     pset%sfh=sfh
@@ -134,7 +142,10 @@ contains
     pset%sigma_smooth=sigma_smooth
     pset%min_wave_smooth=min_wave_smooth
     pset%max_wave_smooth=max_wave_smooth
-
+    pset%gas_logu=gas_logu
+    pset%gas_logz=gas_logz
+    pset%igm_factor=igm_factor
+    
   end subroutine
 
   subroutine ssps
@@ -300,18 +311,11 @@ contains
 
   end subroutine
 
-  subroutine get_setup_vars(cvms, rcolors, svel, asr, ane, ade, agbd, agbn)
+  subroutine get_setup_vars(cvms)
 
     implicit none
-    integer, intent(out) :: cvms, rcolors, svel, asr, ane, ade, agbd, agbn
+    integer, intent(out) :: cvms
     cvms = compute_vega_mags
-    rcolors = redshift_colors
-    svel = smooth_velocity
-    asr = add_stellar_remnants
-    ane = add_neb_emission 
-    ade = add_dust_emission
-    agbd = add_agb_dust_model
-    agbn = tpagb_norm_type
 
   end subroutine
 

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -55,9 +55,15 @@ class StellarPopulation(object):
         wavelength space.
 
     :param add_stellar_remnants: (default: True)
-        Switch to add stellar remnnants in the stellar mass
+        Switch to add stellar remnants in the stellar mass
         computation.
 
+    :param add_igm_absorption: (default: False)
+        Switch to include IGM absorption via Madau (1995).  The
+        ``zred`` parameter must be non-zero for this switch to have
+        any effect. The optical depth can be scaled using the
+        ``igm_factor`` parameter.
+        
     :param add_neb_emission: (default: False)
         Switch to turn on/off a Cloudy-based nebular emission
         model. NB: this feature is currently under development, do not
@@ -174,7 +180,8 @@ class StellarPopulation(object):
         ``zred``.
 
     :param pmetals: (default: 0.02)
-        Undocumented.
+        Metal yield for a closed box distribution.  Not used by
+        python-fsps.
 
     :param imf1: (default: 1.3)
         Logarithmic slope of the IMF over the range :math:`0.08 < M < 0.5
@@ -212,7 +219,9 @@ class StellarPopulation(object):
         are :math:`\\log (\\mathrm{yrs})`.
 
     :param frac_obrun: (default: 0.0)
-        Undocumented.
+        Fraction of the young stars (age < dust_tesc) that are not
+        attenuated by ``dust1``, representing runaway OB stars.  These
+        stars are still attenuated by ``dust2``.
 
     :param uvb: (default: 1.0)
         Parameter characterizing the strength of the 2175A extinction feature
@@ -228,7 +237,9 @@ class StellarPopulation(object):
         Weighting of red  giant branch.
 
     :param dust1_index: (default: -1.0)
-        Undocumented.
+        Power law index of the attenuation curve affecting stars
+        younger than dust_tesc corresponding to ``dust1``. Only used
+        when ``dust_type=0``.
 
     :param mdave: (default: 0.5)
         IMF parameter defined in Dave (2008). Only used if ``imf_type=4``.
@@ -311,7 +322,7 @@ class StellarPopulation(object):
         Gordon (2000) for details.
 
     :param evtype: (default: -1)
-        Compute SSPs for only the given evolutionary type
+        Compute SSPs for only the given evolutionary type.
 
     :param sigma_smooth: (default: 0.0)
         If smooth_velocity is True, this gives the velocity dispersion in
@@ -322,23 +333,40 @@ class StellarPopulation(object):
         Scales the circumstellar AGB dust emission.
 
     :param min_wave_smooth: (default: 1e3)
-        Undocumented.
+        Minimum wavelength to consider when smoothing the spectrum.
 
     :param max_wave_smooth: (default: 1e4)
-        Undocumented.
+        Maximum wavelength to consider when smoothing the spectrum.
 
+    :param gas_logu: (default: -2)
+        Log of the gas ionization parameter, for determining the
+        nebular emission.
+ 
+    :param gas_logz: (default: 0.0)
+        Log of the gas-phase metallicity, for determining the nebular
+        emission.  In units of log10(Z/Z_sun).
+
+    :param igm_factor: (default: 1.0)
+        Fudge factor used to scale the IGM optical depth.
     """
 
-    def __init__(self, compute_vega_mags=True, redshift_colors=False,
-                 smooth_velocity=True, add_stellar_remnants=True,
-                 add_dust_emission=True, add_agb_dust_model=False,
-                 add_neb_emission=False, tpagb_norm_type=1,
-                 zcontinuous=False,**kwargs):
+    def __init__(self, compute_vega_mags=True, zcontinuous=False,
+                 **kwargs):
 
         # Set up the parameters to their default values.
         self.params = ParameterSet(
+            smooth_velocity=True,
+            vactoair_flag=False,
+            redshift_colors=False,
             dust_type=0,
+            add_dust_emission=True,
+            add_agb_dust_model=False,
+            add_neb_emission=False,
+            add_neb_continuum=False,
+            add_igm_absorption=False,
+            add_stellar_remnants=True,
             imf_type=2,
+            tpagb_norm_type=1,
             pagb=1.0,
             dell=0.0,
             delt=0.0,
@@ -386,6 +414,9 @@ class StellarPopulation(object):
             agb_dust=1.0,
             min_wave_smooth=1e3,
             max_wave_smooth=1e4,
+            gas_logu=-2,
+            gas_logz=0.0,
+            igm_factor=1.0,
         )
 
         # Parse any input options.
@@ -400,30 +431,19 @@ class StellarPopulation(object):
         # Before the first time we interact with the FSPS driver, we need to
         # run the ``setup`` method.
         if not driver.is_setup:
-            driver.setup(compute_vega_mags, redshift_colors, smooth_velocity,
-                         add_stellar_remnants, add_neb_emission,
-                         add_dust_emission, add_agb_dust_model,
-                         tpagb_norm_type)
+            driver.setup(compute_vega_mags)
 
         else:
-            cvms, rcolors, svel, asr, ane, ade, agbd, agbn = driver.get_setup_vars()
+            cvms = driver.get_setup_vars()
             assert compute_vega_mags == bool(cvms)
-            assert redshift_colors == bool(rcolors)
-            assert smooth_velocity == bool(svel)
-            assert add_stellar_remnants == bool(asr)
-            assert add_neb_emission == bool(ane)
-            assert add_dust_emission == bool(ade)
-            assert add_agb_dust_model == bool(agbd)
-            assert tpagb_norm_type == agbn
-
-        self._zcontinuous = zcontinuous
             
+        self._zcontinuous = zcontinuous
         # Caching.
         self._wavelengths = None
         self._zlegend = None
         self._ssp_ages = None
         self._stats = None
-        
+
     def _update_params(self):
         if self.params.dirtiness == 2:
             driver.set_ssp_params(*[self.params[k]
@@ -783,17 +803,22 @@ class StellarPopulation(object):
 class ParameterSet(object):
 
     ssp_params = ["imf_type", "imf1", "imf2", "imf3", "vdmc", "mdave",
-                  "dell", "delt", "sbss", "fbhb", "pagb", "agb_dust",
+                  "dell", "delt", "sbss", "fbhb", "pagb", "add_stellar_remnants",
+                  "tpagb_norm_type", "add_agb_dust_model", "agb_dust",
                   "redgb", "masscut", "fcstar", "evtype"]
 
-    csp_params = ["dust_type", "zmet", "sfh", "wgp1", "wgp2", "wgp3",
+    csp_params = ["smooth_velocity", "vactoair_flag", "redshift_colors",
+                  "dust_type", "add_dust_emission", "add_neb_emission",
+                  "add_neb_continuum", "add_igm_absorption",
+                  "zmet", "sfh", "wgp1", "wgp2", "wgp3",
                   "tau", "const", "tage", "fburst", "tburst",
                   "dust1", "dust2", "logzsol", "zred", "pmetals",
                   "dust_clumps", "frac_nodust", "dust_index", "dust_tesc",
                   "frac_obrun", "uvb", "mwr", "dust1_index",
                   "sf_start", "sf_trunc", "sf_theta", "duste_gamma",
                   "duste_umin", "duste_qpah", "sigma_smooth",
-                  "min_wave_smooth", "max_wave_smooth"]
+                  "min_wave_smooth", "max_wave_smooth", "gas_logu",
+                  "gas_logz", "igm_factor"]
 
     @property
     def all_params(self):


### PR DESCRIPTION
Here is the simplified version of PR #24.  This moves many of the StellarPopulation parameters (mostly switches like add_dust_emission and redshift_colors) from initialization to the ParameterSet, since these parameters are not actually used in driver.setup and can be changed safely after instantiation. This should be backwards compatible with code that used these initialization parameters at instantiation. This will also keep python-FSPS nearly as flexible as FSPS. This also fixes a bug whereby changes in dust_type were ignored and the default (dust_type=0) was always used.

It also adds a number of parameters and switches related to nebular emission, igm attenuation, and vacuum to air conversions, and documentation for these parameters.

The FSPS accepted revisions compatible with all these new parameters is now only r171.