### PR TITLE
Changes for FSPS on github

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
 Python-FSPS is developed by (alphabetical by last name):
 
 * `Dan Foreman-Mackey (NYU) <https://github.com/dfm>`_
-* `Ben Johnson (UCSC) <https://github.com/bd-j>`_
+* `Ben Johnson (Harvard/CfA) <https://github.com/bd-j>`_
 * `Jonathan Sick (Queen's) <https://github.com/jonathansick>`_

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 `dan.iel.fm/python-fsps <http://dan.iel.fm/python-fsps>`_
 
 If you use this code, follow the citation requirements `on the FSPS
-homepage <http://people.ucsc.edu/~conroy/FSPS.html>`_ and reference
+homepage <https://github.com/cconroy20/fsps>`_ and reference
 these Python bindings:
 
 .. image:: http://img.shields.io/badge/DOI-10.5281/zenodo.12157-blue.svg?style=flat

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -6,6 +6,6 @@
 
 <p>
     Python-FSPS is a set of bindings to Charlie Conroy's
-    <a href="http://people.ucsc.edu/~conroy/FSPS.html">
+    <a href="https://github.com/cconroy20/fsps">
       Flexible Stellar Population Synthesis</a> Fortran library.
 </p>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -6,6 +6,6 @@
 
 <p>
     Python-FSPS is a set of bindings to Charlie Conroy's
-    <a href="http://people.ucsc.edu/~conroy/FSPS.html">
+    <a href="https://github.com/cconroy20/fsps">
       Flexible Stellar Population Synthesis</a> Fortran library.
 </p>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,11 @@ Flexible Stellar Population Synthesis for Python
 
 These are a set of Python bindings to `Charlie Conroy's Flexible Stellar
 Population Synthesis (FSPS) Fortran library
-<http://people.ucsc.edu/~conroy/FSPS.html>`_.
+<https://github.com/cconroy20/fsps>`_.
 Python-FSPS makes it easy to generate spectra and magnitudes for arbitrary
 stellar populations.
 These bindings are updated in conjunction with FSPS, and are known to work with
-FSPS svn revision 143.
+FSPS v2.5.
 
 
 User Guide
@@ -35,5 +35,5 @@ License
 
 These bindings are available under the `MIT License
 <https://raw.github.com/dfm/python-fsps/master/LICENSE.rst>`_. See the `FSPS
-homepage <http://people.ucsc.edu/~conroy/FSPS.html>`_ for usage
+homepage <https://github.com/cconroy20/fsps>`_ for usage
 restrictions and citation requirements.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,24 +5,25 @@ Prerequisites
 -------------
 
 There are only two required dependencies for building this package: `FSPS
-<http://people.ucsc.edu/~conroy/FSPS.html>`_ (obviously) and `NumPy
+<https://github.com/cconroy20/fsps>`_ (obviously) and `NumPy
 <http://www.numpy.org/>`_.
 First, make sure that you have NumPy installed (using your favorite method)
 and access to the ``f2py`` executable (this should be installed along with
 NumPy).
 
 Then, you need to follow the directions on `the FSPS page
-<http://people.ucsc.edu/~conroy/FSPS.html>`_ to checkout and compile the FSPS
-package. Note that Python-FSPS is built against specific versions of the FSPS
-Fortran API so it may be necessary to checkout a slightly older revision.
-Currently, revision 143 should be used::
+<https://github.com/cconroy20/fsps>`_ to clone and compile the FSPS
+package. Note that Python-FSPS is built against specific versions of
+the FSPS Fortran API so it may be necessary to checkout a slightly
+older commit - you will be notified of this and how to do it when you
+try to import the fsps module.
 
-   svn update -r 143
-
-Once checked out, modify the Makefile as needed and compile FSPS.
-These bindings rely on the value of the ``SPS_HOME`` environment variable
-being correctly set and the compiled ``.o`` and ``.mod`` files be available in
-the ``${SPS_HOME}/src`` directory.
+Once checked out, modify the Makefile as needed and compile FSPS.  For
+some compilers (e.g. intel) it is necessary to set the ``-fPIC`` flag
+when compiling FSPS. These bindings rely on the value of the
+``SPS_HOME`` environment variable being correctly set and the compiled
+``.o`` and ``.mod`` files be available in the ``${SPS_HOME}/src``
+directory.
 
 
 Installing stable version

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -19,8 +19,9 @@ def run_command(cmd):
     child = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     out = [s for s in child.stdout]
+    err = [s for s in child.stderr]
     w = child.wait()
-    return os.WEXITSTATUS(w), out
+    return os.WEXITSTATUS(w), out, err
 
 
 # Check to make sure that the required environment variable is present.
@@ -31,8 +32,9 @@ except KeyError:
 
 # Check the githash, and if there is none check the SVN version
 cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
-stat, out = run_command(" ".join(cmd))
-if len(out) == 0:
+stat, out, err = run_command(" ".join(cmd))
+accepted = (len(out) > 0) an (len(err) == 0)
+if not accepted:
     warnings.warn("Your FSPS version is not under git version "
                   "control. FSPS is now available on github at "
                   "https://github.com/cconroy20/fsps")
@@ -40,7 +42,7 @@ if len(out) == 0:
     # Check the SVN revision number.
     ACCEPTED_FSPS_REVISIONS = [158, 160, 166, 168, 170]
     cmd = ["svnversion", ev]
-    stat, out = run_command(" ".join(cmd))
+    stat, out, err = run_command(" ".join(cmd))
     fsps_vers = int(re.match("^([0-9])+", out[0]).group(0))
 
     # Make sure you don't have some weird mixed version.

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -33,7 +33,7 @@ except KeyError:
 # Check the githash, and if there is none check the SVN version
 cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
 stat, out, err = run_command(" ".join(cmd))
-accepted = (len(out) > 0) an (len(err) == 0)
+accepted = (len(out) > 0) and (len(err) == 0)
 if not accepted:
     warnings.warn("Your FSPS version is not under git version "
                   "control. FSPS is now available on github at "

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -427,49 +427,6 @@ contains
 
   end subroutine
 
-  subroutine get_isochrone(zz,tt,n_mass,n_mags,time_out,z_out,&
-                           mass_init_out,logl_out,logt_out,logg_out,&
-                           ffco_out,phase_out,wght_out,mags_out)
-
-    implicit none
-
-    integer, intent(in) :: zz,tt,n_mass,n_mags
-    double precision, intent(out) :: time_out, z_out
-    double precision, dimension(n_mass), intent(out) :: mass_init_out
-    double precision, dimension(n_mass), intent(out) :: logl_out
-    double precision, dimension(n_mass), intent(out) :: logt_out
-    double precision, dimension(n_mass), intent(out) :: logg_out
-    double precision, dimension(n_mass), intent(out) :: ffco_out
-    double precision, dimension(n_mass), intent(out) :: phase_out
-    double precision, dimension(n_mass), intent(out) :: wght_out
-    double precision, dimension(n_mass, n_mags), intent(out) :: mags_out
-    integer :: i
-    double precision, dimension(nm) :: wght
-    double precision, dimension(nspec)  :: spec
-    double precision, dimension(nbands) :: mags
-
-    call imf_weight(mini_isoc(zz,tt,:), wght, nmass_isoc(zz,tt))
-    do i = 1, nmass_isoc(zz,tt)
-    ! Compute mags on isochrone at this mass
-       call getspec(pset, mact_isoc(zz,tt,i), &
-            logt_isoc(zz,tt,i), 10**logl_isoc(zz,tt,i), logg_isoc(zz,tt,i), &
-            phase_isoc(zz,tt,i), ffco_isoc(zz,tt,i), spec)
-       call getmags(0.d0, spec, mags)
-       mass_init_out(i) = mini_isoc(zz,tt,i)
-       logl_out(i) = logl_isoc(zz,tt,i)
-       logt_out(i) = logt_isoc(zz,tt,i)
-       logg_out(i) = logg_isoc(zz,tt,i)
-       ffco_out(i) = ffco_isoc(zz,tt,i)
-       phase_out(i) = phase_isoc(zz,tt,i)
-       wght_out(i) = wght(i)
-       mags_out(i,:) = mags(:)
-    end do
-
-    ! Fill in time and metallicity of this isochrone
-    time_out = timestep_isoc(zz, tt)
-    z_out = log10(zlegend(zz) / 0.0190) ! log(Z/Zsolar)
-
-  end subroutine
 
   subroutine write_isoc(outfile)
 


### PR DESCRIPTION
Now that FSPS is on github, the SVN revision check will fail for new users (and soon it won't even be possible to get any of the old SVN revisions from googlecode), as discussed in #32 and #33.  

This pull request updates the documentation to reflect the new location of the FSPS code and makes a check for an FSPS githash before falling back to an SVN revision check (and issuing a warning about FSPS now being on github).  Currently the githash check only requires that there is at least one hash - in the future one might require that certain hashes be in the history, or be the most recent hash, or issue a warning if that's not the case.

I also included a note in the docs to address #31 