### PR TITLE
removed routine from fsps.f90 which won't compile with new fsps

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -427,50 +427,6 @@ contains
 
   end subroutine
 
-  subroutine get_isochrone(zz,tt,n_mass,n_mags,time_out,z_out,&
-                           mass_init_out,logl_out,logt_out,logg_out,&
-                           ffco_out,phase_out,wght_out,mags_out)
-
-    implicit none
-
-    integer, intent(in) :: zz,tt,n_mass,n_mags
-    double precision, intent(out) :: time_out, z_out
-    double precision, dimension(n_mass), intent(out) :: mass_init_out
-    double precision, dimension(n_mass), intent(out) :: logl_out
-    double precision, dimension(n_mass), intent(out) :: logt_out
-    double precision, dimension(n_mass), intent(out) :: logg_out
-    double precision, dimension(n_mass), intent(out) :: ffco_out
-    double precision, dimension(n_mass), intent(out) :: phase_out
-    double precision, dimension(n_mass), intent(out) :: wght_out
-    double precision, dimension(n_mass, n_mags), intent(out) :: mags_out
-    integer :: i
-    double precision, dimension(nm) :: wght
-    double precision, dimension(nspec)  :: spec
-    double precision, dimension(nbands) :: mags
-
-    call imf_weight(mini_isoc(zz,tt,:), wght, nmass_isoc(zz,tt))
-    do i = 1, nmass_isoc(zz,tt)
-    ! Compute mags on isochrone at this mass
-       call getspec(pset, mact_isoc(zz,tt,i), &
-            logt_isoc(zz,tt,i), 10**logl_isoc(zz,tt,i), logg_isoc(zz,tt,i), &
-            phase_isoc(zz,tt,i), ffco_isoc(zz,tt,i), spec)
-       call getmags(0.d0, spec, mags)
-       mass_init_out(i) = mini_isoc(zz,tt,i)
-       logl_out(i) = logl_isoc(zz,tt,i)
-       logt_out(i) = logt_isoc(zz,tt,i)
-       logg_out(i) = logg_isoc(zz,tt,i)
-       ffco_out(i) = ffco_isoc(zz,tt,i)
-       phase_out(i) = phase_isoc(zz,tt,i)
-       wght_out(i) = wght(i)
-       mags_out(i,:) = mags(:)
-    end do
-
-    ! Fill in time and metallicity of this isochrone
-    time_out = timestep_isoc(zz, tt)
-    z_out = log10(zlegend(zz) / 0.0190) ! log(Z/Zsolar)
-
-  end subroutine
-
   subroutine write_isoc(outfile)
 
     implicit none


### PR DESCRIPTION
As of FSPS github commit #ccc6061, the calling sequence for getspec changed, which breaks an (unfinished? unused?) routine fsps.f90 (get_isochrone). removed this routine.