### PR TITLE
Metallicity Distribution Function

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -40,7 +40,7 @@ if not accepted:
                   "https://github.com/cconroy20/fsps")
     
     # Check the SVN revision number.
-    ACCEPTED_FSPS_REVISIONS = [189, 190, 191]
+    ACCEPTED_FSPS_REVISIONS = [191]
     cmd = ["svnversion", ev]
     stat, out, err = run_command(" ".join(cmd))
     fsps_vers = int(re.match("^([0-9])+", out[0]).group(0))

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -200,7 +200,10 @@ class StellarPopulation(object):
        The power for the metallicty distribution function.  The MDF is
        given by :math:`(Z \\, e^{{-Z}})^{{pmetals}}` where :math:`Z =
        z/(z_\\odot \\, 10^{{logzsol}})` and z is the metallicity in
-       linear units (i.e., :math:`z_\odot = 0.019`)
+       linear units (i.e., :math:`z_\odot = 0.019`).  Using a negative
+       value will result in smoothing of the SSPs by a three-point
+       triangular kernel before linear interpolation (in logZ) to the
+       requested metallicity.
 
     :param imf1: (default: 1.3)
         Logarithmic slope of the IMF over the range :math:`0.08 < M < 0.5


### PR DESCRIPTION
This PR allows for the use of a metallicity distribution function (MDF) in the stellar population, based on the MDF options in ``ztinterp.f90``

The MDF is switched on by setting ``zcontinuous=2`` at instantiation of the StellarPopulation object.  The MDF is described by two parameters, ``logzsol`` and ``pmetals``, and the functional forms available are described in the documentation of these parameters.

This requires the github version of fsps or SVN revision r191.