### PR TITLE
sf_slope, githash check

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -78,7 +78,7 @@ contains
                             const,tage,fburst,tburst,dust1,dust2,&
                             logzsol,zred,pmetals,dust_clumps,frac_nodust,&
                             dust_index,dust_tesc,frac_obrun,uvb,mwr,&
-                            dust1_index,sf_start,sf_trunc,sf_theta,&
+                            dust1_index,sf_start,sf_trunc,sf_slope,&
                             duste_gamma,duste_umin,duste_qpah,&
                             sigma_smooth,min_wave_smooth,&
                             max_wave_smooth,gas_logu,gas_logz,igm_factor)
@@ -95,7 +95,7 @@ contains
                             const,tage,fburst,tburst,dust1,dust2,&
                             logzsol,zred,pmetals,dust_clumps,frac_nodust,&
                             dust_index,dust_tesc,frac_obrun,uvb,mwr,&
-                            dust1_index,sf_start,sf_trunc,sf_theta,&
+                            dust1_index,sf_start,sf_trunc,sf_slope,&
                             duste_gamma,duste_umin,duste_qpah,&
                             sigma_smooth,min_wave_smooth,&
                             max_wave_smooth,gas_logu,gas_logz,igm_factor
@@ -136,7 +136,7 @@ contains
     pset%dust1_index=dust1_index
     pset%sf_start=sf_start
     pset%sf_trunc=sf_trunc
-    pset%sf_theta=sf_theta
+    pset%sf_slope=sf_slope
     pset%duste_gamma=duste_gamma
     pset%duste_umin=duste_umin
     pset%duste_qpah=duste_qpah

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -272,7 +272,7 @@ class StellarPopulation(object):
     :param sf_trunc: (default: 0.0)
         Undocumented.
 
-    :param sf_theta: (default: 0.0)
+    :param sf_slope: (default: 0.0)
         Undocumented.
 
     :param duste_gamma: (default: 0.01)
@@ -422,7 +422,7 @@ class StellarPopulation(object):
             mdave=0.5,
             sf_start=0.0,
             sf_trunc=0.0,
-            sf_theta=0.0,
+            sf_slope=0.0,
             duste_gamma=0.01,
             duste_umin=1.0,
             duste_qpah=3.5,
@@ -838,7 +838,7 @@ class ParameterSet(object):
                   "dust1", "dust2", "logzsol", "zred", "pmetals",
                   "dust_clumps", "frac_nodust", "dust_index", "dust_tesc",
                   "frac_obrun", "uvb", "mwr", "dust1_index",
-                  "sf_start", "sf_trunc", "sf_theta", "duste_gamma",
+                  "sf_start", "sf_trunc", "sf_slope", "duste_gamma",
                   "duste_umin", "duste_qpah", "sigma_smooth",
                   "min_wave_smooth", "max_wave_smooth", "gas_logu",
                   "gas_logz", "igm_factor"]


### PR DESCRIPTION
This PR supports the parameter name change ``sf_theta`` --> ``sf_slope`` introduced in  cconroy20/fsps@6ad1058e1624f 

It also now drops the check for an SVN revision.  FSPS _must_ be installed via github, and it must have "6ad1058e16" in its history.