### PR TITLE
Ssp speed

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -327,18 +327,20 @@ contains
 
   end subroutine
 
-  subroutine get_mags(n_age,n_bands,z_red,mc,mags)
+  subroutine get_mags(ns,n_age,n_bands,z_red,mc,mags)
 
     ! Get the photometric magnitudes in all the recognized bands.
     
     implicit none
     integer :: i
-    integer, intent(in) :: n_age, n_bands
+    integer, intent(in) :: ns, n_age, n_bands
     double precision, intent(in) :: z_red
     integer, dimension(n_bands), intent(in) :: mc
     double precision, dimension(n_age,n_bands), intent(out) :: mags
+    double precision, dimension(ns) :: tspec
     do i=1,n_age
-      call getmags(z_red,ocompsp(i)%spec,mags(i,:),mc)
+      tspec = ocompsp(i)%spec
+      call getmags(z_red,tspec,mags(i,:),mc)
     enddo
 
   end subroutine

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -529,10 +529,10 @@ class StellarPopulation(object):
             factor = np.ones_like(wavegrid)
 
         NSPEC = driver.get_nspec()
-        NTFULL = driver.get_ntfull()
         if tage > 0.0:
-            return wavegrid, driver.get_spec(NSPEC, NTFULL)[0] * factor
-
+            return wavegrid, driver.get_spec(NSPEC, 1)[0] * factor
+        
+        NTFULL = driver.get_ntfull()
         return wavegrid, driver.get_spec(NSPEC, NTFULL) * factor[None, :]
 
     @property
@@ -601,11 +601,14 @@ class StellarPopulation(object):
         self.params["tage"] = tage
         if zmet is not None:
             self.params["zmet"] = zmet
-
+        
         if self.params.dirty:
             self._compute_csp()
-
-        NTFULL = driver.get_ntfull()
+        
+        if tage > 0.0:
+            NTFULL = 1
+        else:
+            NTFULL = driver.get_ntfull()
         NBANDS = driver.get_nbands()
         NSPEC = driver.get_nspec()
         

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -607,7 +607,8 @@ class StellarPopulation(object):
 
         NTFULL = driver.get_ntfull()
         NBANDS = driver.get_nbands()
-
+        NSPEC = driver.get_nspec()
+        
         band_array = np.ones(NBANDS, dtype=bool)
         if bands is not None:
             user_sorted_inds = np.array([FILTERS[band.lower()].index
@@ -617,7 +618,7 @@ class StellarPopulation(object):
                                 dtype=bool)] = False
 
         inds = np.array(band_array, dtype=int)
-        mags = driver.get_mags(NTFULL, redshift, inds)
+        mags = driver.get_mags(NSPEC, NTFULL, redshift, inds)
 
         if tage > 0.0:
             if bands is not None:


### PR DESCRIPTION
This PR fixes an issue where repeated calls to get mags with non-zero redshift and no other parameter changes would result in different results because of cumulative repeated redshifting of the CSP spectrum.

It also includes small changes that can result in faster generation of SSP spectra, especially using the ``ztinterp`` method with ``pset%ssp_gen_age=0`` in the fsps ``sps.vars.f90`` file.