### PR TITLE
Docs and style cleanup

### DIFF
--- a/demos/specbymass.py
+++ b/demos/specbymass.py
@@ -1,0 +1,169 @@
+# This demo shows how to make a plot of the fractional contribution of differnt
+# stellar mass ranges to the total spectrum, for different properties of the
+# stellar population.  There is also some use of the filter objects.
+
+from itertools import product
+import numpy as np
+import matplotlib.pyplot as pl
+import fsps
+
+# make an SPS object with interpolation in metallicity enabled, and
+# set a few parameters
+sps = fsps.StellarPopulation(zcontinuous=1)
+sps.params['imf_type'] = 0   # Salpeter IMF
+sps.params['sfh'] = 1  # Tau model SFH
+
+# Get a few filter transmission curves
+filterlist = {'galex_fuv': 'FUV', 'galex_nuv': 'NUV', 'sdss_u': 'u',
+              'sdss_g': 'g', 'sdss_i': 'i', '2mass_j': 'J'}
+filters = [fsps.filters.get_filter(f) for f in filterlist]
+
+
+# This is the main function
+def specplots(tage=10.0, const=1.0, tau=1.0, neb=False, z=0.0, savefig=True,
+              masslims=[1.0, 3.0, 15.0, 30.0, 120.0], **kwargs):
+    """Make a number of plots showing the fraction of the total light due to
+    stars within certain stellar mass ranges.
+
+    :param tage:
+        The age of the stellar population
+
+    :param const:
+        0 or 1.  fraction of SF in constant SFR fraction
+
+    :param tau:
+        If const is 0, this is the decay timescale (in Gyr) of the
+        exponentially declining SFR.
+
+    :param neb:
+        Boolean.  Whether to include the contribution of emission lines.
+
+    :param z:
+        Metallicity, in units of log Z/Z_\odot
+
+    :param masslims:
+        The edges of the stellar mass bins to plot, in solar masses.
+
+    :param savefig:
+        If True save the figures to pdfs
+
+    :returns cfig:
+        matplotlib figure giving a plot of the spectrum of stars *less than* a
+        given upper stellar mass limit
+
+    :returns dfig:
+        matplotlib figure giving a plot of the spectrum of stars in given mass
+        ranges.
+
+    :returns ffig:
+        matplotlib figure giving a plot of the fraction of total flux due to
+        stars in given mass ranges, as a function of wavelength.
+    """
+    # Set the FSPS params
+    sps.params['const'] = const
+    sps.params['tau'] = tau
+    sps.params['add_neb_emission'] = neb
+    sps.params['masscut'] = 120
+    sps.params['logzsol'] = z
+    # Try to set any extra params
+    for k, v in kwargs:
+        try:
+            sps.params[k] = v
+        except(KeyError):
+            pass
+
+    # Make a pretty string with the FSPS parameters
+    sfh = {1: 'Constant SFR', 0: r'$\tau_{{SF}}={}$'.format(sps.params['tau'])}
+    sfhname = {1: 'const', 0: 'tau{}'.format(sps.params['tau'])}
+    name = '{}_z{}_neb{}'.format(sfhname[int(const)], z, neb)
+
+    # get the total spectrum due to *all* stars
+    wave, spec_tot = sps.get_spectrum(tage=tage)
+
+    # Set up stellar mass ranges and arrays to hold output spectra
+    mspec = np.zeros([len(sps.wavelengths), len(masslims)])
+    dmspec = np.zeros_like(mspec)
+
+    # set up figure and axis objects
+    cfig, cax = pl.subplots(figsize=(12.4, 7.5))
+    dfig, dax = pl.subplots(figsize=(12.4, 7.5))
+    ffig, fax = pl.subplots(figsize=(12.4, 7.5))
+    [ax.set_xlim(0.9e3, 1e4) for ax in [cax, fax, dax]]
+
+    # Loop over upper mass limits, generating spectrum for each one
+    for i, mc in enumerate(masslims):
+        # set the upper stellar mass limit
+        sps.params['masscut'] = mc
+        # get the spectrum at age = tage and store it
+        w, spec = sps.get_spectrum(tage=tage)
+        mspec[:, i] = spec.copy()
+        # plot the spectrum due to stars less massive than the limit
+        cax.plot(w, spec, label='M < {}'.format(mc))
+
+        if i == 0:
+            # Plot the lowest mass bin spectrum
+            dax.plot(w, spec, label='{} < M < {}'.format(0.08, mc))
+            fax.plot(w, spec / spec_tot, label='{} < M < {}'.format(0.08, mc))
+            # skip the rest of the loop
+            continue
+
+        # Subtract the spectrum from the last upper limit to ge tthe
+        #  spectrum due to stars within the bin
+        dmspec[:, i] = spec - mspec[:, i-1]
+        # Plot it
+        label = '{} < M < {}'.format(masslims[i-1], mc)
+        dax.plot(w, dmspec[:, i], label=label)
+        # Plot the total spectrum
+        if mc == masslims[-1]:
+            dax.plot(w, spec, label='Total', color='black')
+
+        # plot the fractional
+        fax.plot(w, dmspec[:, i] / spec_tot, label=label)
+
+    # prettify the axes, titles, etc
+    [ax.legend(loc=0) for ax in [cax, dax, fax]]
+    [ax.set_xlabel('$\lambda (\AA)$') for ax in [cax, dax, fax]]
+    [ax.set_ylabel('$F_\lambda$') for ax in [cax, dax]]
+    [ax.set_yscale('log') for ax in [cax, dax]]
+    [ax.set_ylim(1e-20, 1e-14) for ax in [cax, dax]]
+    fstring = 'Age = {} Gyr, {}, log$Z/Z_\odot$={}'
+    vals = 10.0, sfh[int(sps.params['const'])], sps.params['logzsol']
+    [ax.set_title(fstring.format(*vals)) for ax in [cax, dax, fax]]
+    fax.set_ylabel('$F/F_{tot}$')
+
+    # plot filter transmission curves as shaded regions
+    for f in filters:
+        wavelength, transmission = f.transmission
+        tmax = transmission.max()
+        wmax = wavelength[transmission.argmax()]
+        fax.fill_between(wavelength, transmission / tmax * 0.8,
+                         alpha=0.3, color='grey')
+        fax.text(wmax, 0.83, filterlist[f.name], fontdict={'size': 16})
+
+    if savefig:
+        # save to pdf
+        cfig.savefig('cspec_'+name+'.pdf')
+        dfig.savefig('dspec_'+name+'.pdf')
+        ffig.savefig('fspec_'+name+'.pdf')
+
+    return cfig, dfig, ffig
+
+
+if __name__ == "__main__":
+
+    # set the stellar population age
+    tage = 10.0  # in Gyr
+
+    # Parameters to loop over
+    # ----------
+    # log Z/Z_sun
+    zs = [-1.0, 0.0]
+    # Whether to include nebular emission
+    nebs = [True, False]
+    # Fraction of SF in constant SFR.  should be 0 or 1 for these plots
+    const = [1.0]
+
+    # loop over parameters, and show the fractional plot
+    for z, n, c in product(zs, nebs, const):
+        cf, df, ff = specplots(tage=tage, z=z, const=c, neb=n, savefig=False)
+        ff.show()

--- a/demos/specbymass.py
+++ b/demos/specbymass.py
@@ -66,7 +66,7 @@ def specplots(tage=10.0, const=1.0, tau=1.0, neb=False, z=0.0, savefig=True,
     sps.params['masscut'] = 120
     sps.params['logzsol'] = z
     # Try to set any extra params
-    for k, v in kwargs:
+    for k, v in kwargs.items():
         try:
             sps.params[k] = v
         except(KeyError):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ templates_path = ["_templates"]
 
 # General information about the project.
 project = "Python FSPS"
-copyright = "2013-2014 Dan Foreman-Mackey & contributors"
+copyright = "2013-2015 Dan Foreman-Mackey & contributors"
 # version =
 # release =
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,23 +9,25 @@ There are only two required dependencies for building this package: `FSPS
 <http://www.numpy.org/>`_.
 First, make sure that you have NumPy installed (using your favorite method)
 and access to the ``f2py`` executable (this should be installed along with
-NumPy).  Note that ``f2py`` versions packaged with numpy v1.10.x do
-not work, please use numpy v1.9.x or lower.
+NumPy).  Note that ``f2py`` versions packaged with ``numpy`` v1.10.x do
+not work with python-FSPS, please use ``numpy`` v1.9.3 or lower.
 
 Then, you need to follow the directions on `the FSPS page
 <https://github.com/cconroy20/fsps>`_ to clone and compile the FSPS
 package. Note that Python-FSPS is built against specific versions of
-the FSPS Fortran API so it may be necessary to checkout a slightly
-older commit - you will be notified of this and how to do it when you
-try to import the fsps module.
+the FSPS Fortran API, so it is important that you have a recent tagged
+release version of FSPS.  If you are missing required updates to FSPS
+you will be notified of this when you try to build Python-FSPS.
+Currently Python-FSPS is built against FSPS v2.6.
 
-Once checked out, modify the Makefile as needed and compile FSPS.  For
-some compilers (e.g. Intel) it may be necessary to set the ``-fPIC``
-flag when compiling FSPS -- please try this if you encounter
-python-FSPS build errors.  These bindings rely on the value of the
-``SPS_HOME`` environment variable being correctly set and the compiled
-``.o`` and ``.mod`` files be available in the ``${SPS_HOME}/src``
-directory.
+Once FSPS is checked out, modify the Makefile as needed and compile
+FSPS.  For some compilers (e.g. Intel) it may be necessary to set the
+``-fPIC`` flag when compiling FSPS -- please try this if you encounter
+Python-FSPS build errors.
+
+These bindings rely on the value of the ``SPS_HOME`` environment
+variable being correctly set and the compiled ``.o`` and ``.mod``
+files be available in the ``${SPS_HOME}/src`` directory.
 
 
 Installing development version
@@ -50,8 +52,8 @@ most recent stable version of python-fsps using pip:
 
     pip install fsps
 
-If this does not work, please follow the instruction above for
-installing the development version.
+If this does not work, please ``pip uninstall fsps`` and follow the
+instructions above for installing the development version.
 
 
 Testing the installation

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -4,7 +4,7 @@
 from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 import os
 import re

--- a/fsps/filters.py
+++ b/fsps/filters.py
@@ -119,10 +119,12 @@ class Filter(object):
                     filter_index += 1
                     lambdas, trans = [], []
                 else:
-                    l, t = line.split()
-                    lambdas.append(float(l))
-                    trans.append(float(t))
-
+                    try:
+                        l, t = line.split()
+                        lambdas.append(float(l))
+                        trans.append(float(t))
+                    except(ValueError):
+                        pass
 
 def _load_filter_dict():
     """

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -20,7 +20,7 @@ class StellarPopulation(object):
     of the parameters of the system using keyword arguments. Below, you'll
     find a list of the options that you can include (with the comments taken
     directly from the `FSPS docs
-    <http://www.ucolick.org/~cconroy/FSPS_files/MANUAL.pdf>`_. To change
+    <https://github.com/cconroy20/fsps/blob/master/doc/MANUAL.pdf>`_. To change
     these values later, use the ``params`` property—which is ``dict``-like.
     For example:
 
@@ -32,7 +32,6 @@ class StellarPopulation(object):
     :param compute_vega_mags: (default: False)
         A switch that sets the zero points of the magnitude system: ``True``
         uses Vega magnitudes versus AB magnitudes.
-
 
     :param vactoair_flag: (default: False)
         If ``True``, output wavelengths in air (rather than vac).
@@ -51,6 +50,8 @@ class StellarPopulation(object):
           parameters. The value of ``zmet`` is ignored.
 
     :param redshift_colors: (default: False)
+        Flag specifying how to compute magnitudes:
+        
         * ``False``: Magnitudes are computed at a fixed redshift specified
           by ``zred``.
         * ``True``: Magnitudes are computed at a redshift that corresponds
@@ -97,6 +98,7 @@ class StellarPopulation(object):
 
     :param tpagb_norm_type: (default: 2)
         Flag specifying TP-AGB normalization scheme:
+        
         * 0: default Padova 2007 isochrones
         * 1: Conroy & Gunn 2010 normalization
         * 2: Villaume, Conroy, Johnson 2015 normalization
@@ -538,7 +540,7 @@ class StellarPopulation(object):
     @property
     def wavelengths(self):
         """
-        The wavelength scale for the computed spectra.
+        The wavelength scale for the computed spectra, in :math:`\AA`
 
         """
         if self._wavelengths is None:
@@ -649,14 +651,14 @@ class StellarPopulation(object):
         metallicity will be regenerated, if parameters are dirty.
 
         :param zpos:
-            The metallicity, in units of log(Z/Z_sun)
+            The metallicity, in units of :math:`log(Z/Z_\odot)`
 
         :param tpos:
             The desired age, in Gyr.
 
         :param peraa: (default: False)
-            If true, return spectra in units of L_sun/AA, otherwise
-            L_sun/Hz
+            If true, return spectra in units of :math:`L_\odot/\AA`, otherwise
+            :math:`L_\odot/\mathrm{Hz}`
 
         :returns spec:
             The SSP spectrum, interpolated to zpos and tpos.
@@ -688,11 +690,11 @@ class StellarPopulation(object):
         :param update: (default: True)
             If True, forces an update of the SSPs if the ssp
             parameters have changed. Otherwise simply dumps the
-            current contents of the ssp_spec_zz array.
+            current contents of the ``ssp_spec_zz`` array.
 
         :param peraa: (default: False)
-            If true, return spectra in units of L_sun/AA, otherwise
-            L_sun/Hz
+            If true, return spectra in units of :math:`L_\odot/\AA`, otherwise
+            :math:`L_\odot/\mathrm{Hz}`
 
         :returns spec:
             The spectra of the SSPs, having shape (nspec, ntfull, nz).
@@ -772,7 +774,7 @@ class StellarPopulation(object):
             The log of the effective temperature.
 
         :param lbol:
-            Stellar luminosity, L_star/L_\sun
+            Stellar luminosity, in units of :math:`L_\odot`
 
         :param logg:
             Log of the surface gravity g.  Note that this variable is
@@ -794,7 +796,7 @@ class StellarPopulation(object):
             The IMF weight
 
         :returns outspec:
-            The spectrum of the star, in L_sun/Hz
+            The spectrum of the star, in :math:`L_\odot/\mathrm{Hz}`
         """
         if zmet is not None:
             self.params["zmet"] = zmet
@@ -829,7 +831,7 @@ class StellarPopulation(object):
             A list of the column names pulled from the header of the
             .cmd file.  The number of column names will not match the
             number of columns in dat since there are as many ``mags``
-            as filters.  Use fsps.list_filters() to get the ordered
+            as filters.  Use ``fsps.list_filters()`` to get the ordered
             filter name list.
         """
         if self.params.dirty:
@@ -860,7 +862,7 @@ class StellarPopulation(object):
 
     @property
     def log_lbol(self):
-        """log(bolometric luminosity / L_solar)."""
+        """log(bolometric luminosity / :math:`L_\odot/`)."""
         return self._stat(2)
 
     @property

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -37,86 +37,78 @@ class StellarPopulation(object):
         If ``True``, output wavelengths in air (rather than vac).
 
     :param zcontinuous: (default: 0)
-        Flag specifying how interpolation in metallicity is
-        performed before computing composite models:
-        
-        * 0: No interpolation, use the metallicity index specified by
-          ``zmet``.
-        * 1: The SSPs are interpolated to the value of ``logzsol``
-          before the spectra and magnitudes are computed, and the
-          value of ``zmet`` is ignored.
-        * 2: The SSPs are convolved with a metallicity distribution
-          function specified by the ``logzsol`` and ``pmetals``
-          parameters. The value of ``zmet`` is ignored.
+        Flag specifying how interpolation in metallicity is performed before
+        computing composite models:
+
+        * 0: No interpolation, use the metallicity index specified by ``zmet``.
+        * 1: The SSPs are interpolated to the value of ``logzsol`` before the
+          spectra and magnitudes are computed, and the value of ``zmet`` is
+          ignored.
+        * 2: The SSPs are convolved with a metallicity distribution function
+          specified by the ``logzsol`` and ``pmetals`` parameters. The value of
+          ``zmet`` is ignored.
 
     :param redshift_colors: (default: False)
         Flag specifying how to compute magnitudes:
-        
-        * ``False``: Magnitudes are computed at a fixed redshift specified
-          by ``zred``.
-        * ``True``: Magnitudes are computed at a redshift that corresponds
-          to the age of the output SSP/CSP (assuming a redshift–age relation
-          appropriate for a WMAP5 cosmology). This switch is useful if
-          the user wants to compute the evolution in observed colors of a
-          SSP/CSP.
+
+        * ``False``: Magnitudes are computed at a fixed redshift specified by
+          ``zred``.
+        * ``True``: Magnitudes are computed at a redshift that corresponds to
+          the age of the output SSP/CSP (assuming a redshift–age relation
+          appropriate for a WMAP5 cosmology). This switch is useful if the user
+          wants to compute the evolution in observed colors of a SSP/CSP.
 
     :param smooth_velocity: (default: True)
-        Switch to choose smoothing in velocity space (``True``) or
-        wavelength space.
+        Switch to choose smoothing in velocity space (``True``) or wavelength
+        space.
 
     :param add_stellar_remnants: (default: True)
-        Switch to add stellar remnants in the stellar mass
-        computation.
+        Switch to add stellar remnants in the stellar mass computation.
 
     :param add_igm_absorption: (default: False)
-        Switch to include IGM absorption via Madau (1995).  The
-        ``zred`` parameter must be non-zero for this switch to have
-        any effect. The optical depth can be scaled using the
-        ``igm_factor`` parameter.
-        
+        Switch to include IGM absorption via Madau (1995).  The ``zred``
+        parameter must be non-zero for this switch to have any effect. The
+        optical depth can be scaled using the ``igm_factor`` parameter.
+
     :param add_neb_emission: (default: False)
-        Switch to turn on/off a Cloudy-based nebular emission
-        model. 
+        Switch to turn on/off a Cloudy-based nebular emission model.
 
     :param add_neb_continuum: (default: True)
-        Switch to turn on/off the nebular continuum component
-        (automatically turned off if ``add_neb_emission`` is
-        ``False``).
+        Switch to turn on/off the nebular continuum component (automatically
+        turned off if ``add_neb_emission`` is ``False``).
 
     :param cloudy_dust: (default: False)
         Switch to include dust in the Cloudy tables.
-        
+
     :param add_dust_emission: (default: True)
-        Switch to turn on/off the Draine & Li 2007 dust emission
-        model.
+        Switch to turn on/off the Draine & Li 2007 dust emission model.
 
     :param add_agb_dust_model: (default: True)
-        Switch to turn on/off the AGB circumstellar dust model. NB:
-        this feature is currently under development, do not use!  If
-        you do use it, note that the AGB dust emission is scaled by
-        the parameter `agb_dust`.
+        Switch to turn on/off the AGB circumstellar dust model. NB: The AGB
+        dust emission is scaled by the parameter `agb_dust`.
 
     :param tpagb_norm_type: (default: 2)
         Flag specifying TP-AGB normalization scheme:
-        
+
         * 0: default Padova 2007 isochrones
         * 1: Conroy & Gunn 2010 normalization
         * 2: Villaume, Conroy, Johnson 2015 normalization
-        
+
     :param dust_type: (default: 0)
-        Common variable deﬁning the extinction curve for dust around old
-        stars:
+        Common variable deﬁning the extinction curve for dust around old stars:
 
         * 0: power law with index dust index set by ``dust_index``.
-        * 1: Milky Way extinction law (with :math:`R = A_V /E(B - V)` value
-          ``mwr``) parameterized by Cardelli et al. (1989).
-        * 2: Calzetti et al. (2000) attenuation curve. Note that if this
-          value is set then the dust attenuation is applied to all starlight
-          equally (not split by age), and therefore the only relevant
-          parameter is ``dust2``, which sets the overall normalization.
+        * 1: Milky Way extinction law (with the :math:`R = A_V /E(B - V)` value
+          given by ``mwr``) parameterized by Cardelli et al. (1989).
+        * 2: Calzetti et al. (2000) attenuation curve. Note that if this value
+          is set then the dust attenuation is applied to all starlight equally
+          (not split by age), and therefore the only relevant parameter is
+          ``dust2``, which sets the overall normalization.
         * 3: allows the user to access a variety of attenuation curve models
-          from Witt & Gordon (2000) using the parameters ``wgp1`` and
-          ``wgp2``.
+          from Witt & Gordon (2000) using the parameters ``wgp1`` and ``wgp2``.
+        * 4: Kriek & Conroy 2013 attenuation curve.  In this model the slope of
+          the curve, set by the parameter ``dust_index``, is linked to the
+          strength of the UV bump.
 
     :param imf_type: (default: 2)
         Common variable defining the IMF type:
@@ -126,13 +118,13 @@ class StellarPopulation(object):
         * 2: Kroupa (2001)
         * 3: van Dokkum (2008)
         * 4: Dave (2008)
-        * 5: tabulated piece-wise power law IMF, specified in ``imf.dat``
-          file located in the data directory
+        * 5: tabulated piece-wise power law IMF, specified in ``imf.dat`` file
+          located in the data directory
 
     :param pagb: (default: 1.0)
         Weight given to the post–AGB phase. A value of 0.0 turns off post-AGB
-        stars; a value of 1.0 implies that the Vassiliadis & Wood (1994)
-        tracks are implemented as–is.
+        stars; a value of 1.0 implies that the Vassiliadis & Wood (1994) tracks
+        are implemented as–is.
 
     :param dell: (default: 0.0)
         Shift in :math:`\log L_\mathrm{bol}` of the TP-AGB isochrones. Note
@@ -146,8 +138,8 @@ class StellarPopulation(object):
 
     :param fbhb: (default: 0.0)
         Fraction of horizontal branch stars that are blue. The blue HB stars
-        are uniformly spread in :math:`\log T_\mathrm{eff}` to `10^4` K. See
-        Conroy et al. (2009a) for details and a plausible range.
+        are uniformly spread in :math:`\log T_\mathrm{eff}` to :math:`10^4`
+        K. See Conroy et al. (2009a) for details and a plausible range.
 
     :param sbss: (default: 0.0)
         Specific frequency of blue straggler stars. See Conroy et al. (2009a)
@@ -161,24 +153,23 @@ class StellarPopulation(object):
         Defines the constant component of the SFH. This quantity is defined
         as the fraction of mass formed in a constant mode of SF; the range
         is therefore :math:`0 \le C \le 1`. Only used if ``sfh=1`` or
-        ``sf=4``.
+        ``sfh=4``.
 
     :param tage: (default: 0.0)
         If set to a non-zero value, the
         :func:`fsps.StellarPopulation.compute_csp` method will compute the
-        spectra and magnitudes only at this age, and will therefore only
-        output one age result. The units are Gyr. (The default is to compute
-        and return results from :math:`t \\approx 0` to the maximum age in
-        the isochrones).
+        spectra and magnitudes only at this age, and will therefore only output
+        one age result. The units are Gyr. (The default is to compute and
+        return results from :math:`t \\approx 0` to the maximum age in the
+        isochrones).
 
     :param fburst: (default: 0.0)
         Deﬁnes the fraction of mass formed in an instantaneous burst of star
         formation. Only used if ``sfh=1`` or ``sfh=4``.
 
     :param tburst: (default: 11.0)
-        Defines the age of the Universe when the burst occurs. If
-        ``tburst > tage`` then there is no burst. Only used if ``sfh=1`` or
-        ``sfh=4``.
+        Defines the age of the Universe when the burst occurs. If ``tburst >
+        tage`` then there is no burst. Only used if ``sfh=1`` or ``sfh=4``.
 
     :param dust1: (default: 0.0)
         Dust parameter describing the attenuation of young stellar light,
@@ -189,23 +180,22 @@ class StellarPopulation(object):
         i.e. where ``t > dust_tesc`` (for details, see Conroy et al. 2009a).
 
     :param logzsol: (default: 0.0)
-        Parameter describing the metallicity, given in units of
-        log(Z/Z_sun).  Only used if ``zcontinuous=1`` or
-        ``zcontinuous=2``.
+        Parameter describing the metallicity, given in units of :math:`\log
+        (Z/Z_\odot)`.  Only used if ``zcontinuous > 0``.
 
     :param zred: (default: 0.0)
-        Redshift. If this value is non-zero and if ``redshift_colors=1``,
-        the magnitudes will be computed for the spectrum placed at redshift
+        Redshift. If this value is non-zero and if ``redshift_colors=1``, the
+        magnitudes will be computed for the spectrum placed at redshift
         ``zred``.
 
     :param pmetals: (default: 2.0)
-       The power for the metallicty distribution function.  The MDF is
-       given by :math:`(Z \\, e^{{-Z}})^{{pmetals}}` where :math:`Z =
-       z/(z_\\odot \\, 10^{{logzsol}})` and z is the metallicity in
-       linear units (i.e., :math:`z_\odot = 0.019`).  Using a negative
-       value will result in smoothing of the SSPs by a three-point
-       triangular kernel before linear interpolation (in logZ) to the
-       requested metallicity.
+       The power for the metallicty distribution function.  The MDF is given by
+       :math:`(Z \\, e^{{-Z}})^{{\mathrm{pmetals}}}` where :math:`Z =
+       z/(z_\\odot \\, 10^{{\mathrm{logzsol}}})` and z is the metallicity in
+       linear units (i.e., :math:`z_\odot = 0.019`).  Using a negative value
+       will result in smoothing of the SSPs by a three-point triangular kernel
+       before linear interpolation (in :math:`\log Z`) to the requested
+       metallicity.
 
     :param imf1: (default: 1.3)
         Logarithmic slope of the IMF over the range :math:`0.08 < M < 0.5
@@ -243,9 +233,9 @@ class StellarPopulation(object):
         are :math:`\\log (\\mathrm{yrs})`.
 
     :param frac_obrun: (default: 0.0)
-        Fraction of the young stars (age < dust_tesc) that are not
-        attenuated by ``dust1``, representing runaway OB stars.  These
-        stars are still attenuated by ``dust2``.
+        Fraction of the young stars (age < dust_tesc) that are not attenuated
+        by ``dust1``, representing runaway OB stars.  These stars are still
+        attenuated by ``dust2``.
 
     :param uvb: (default: 1.0)
         Parameter characterizing the strength of the 2175A extinction feature
@@ -261,9 +251,8 @@ class StellarPopulation(object):
         Weighting of red  giant branch.
 
     :param dust1_index: (default: -1.0)
-        Power law index of the attenuation curve affecting stars
-        younger than dust_tesc corresponding to ``dust1``. Only used
-        when ``dust_type=0``.
+        Power law index of the attenuation curve affecting stars younger than
+        dust_tesc corresponding to ``dust1``. Only used when ``dust_type=0``.
 
     :param mdave: (default: 0.5)
         IMF parameter defined in Dave (2008). Only used if ``imf_type=4``.
@@ -278,20 +267,19 @@ class StellarPopulation(object):
         Undocumented.
 
     :param duste_gamma: (default: 0.01)
-        Parameter of the Draine & Li (2007) dust emission model. Specifies
-        the relative contribution of dust heated at a radiation field
-        strength of :math:`U_\mathrm{min}` and dust heated at
-        :math:`U_\mathrm{min} < U \le U_\mathrm{max}`. Allowable range is 0.0
-        – 1.0.
+        Parameter of the Draine & Li (2007) dust emission model. Specifies the
+        relative contribution of dust heated at a radiation field strength of
+        :math:`U_\mathrm{min}` and dust heated at :math:`U_\mathrm{min} < U \le
+        U_\mathrm{max}`. Allowable range is 0.0 – 1.0.
 
     :param duste_umin: (default: 1.0)
-        Parameter of the Draine & Li (2007) dust emission model. Specifies
-        the minimum radiation field strength in units of the MW value. Valid
-        range is 0.1 – 25.0.
+        Parameter of the Draine & Li (2007) dust emission model. Specifies the
+        minimum radiation field strength in units of the MW value. Valid range
+        is 0.1 – 25.0.
 
     :param duste_qpah: (default: 3.5)
-        Parameter of the Draine & Li (2007) dust emission model. Specifies
-        the grain size distribution through the fraction of grain mass in
+        Parameter of the Draine & Li (2007) dust emission model. Specifies the
+        grain size distribution through the fraction of grain mass in
         PAHs. This parameter has units of % and a valid range of 0.0 − 10.0.
 
     :param fcstar: (default: 1.0)
@@ -304,8 +292,8 @@ class StellarPopulation(object):
         Truncate the IMF above this value.
 
     :param zmet: (default: 1)
-        The metallicity is specified as an integer ranging between 1
-        and nz. If ``zcontinuous > 0`` then this parameter is ignored.
+        The metallicity is specified as an integer ranging between 1 and nz. If
+        ``zcontinuous > 0`` then this parameter is ignored.
 
     :param sfh: (default: 0)
         Defines the type of star formation history, normalized such that one
@@ -313,15 +301,16 @@ class StellarPopulation(object):
 
         * 0: Compute an SSP
         * 1: Compute a five parameter SFH (see below).
-        * 2: Compute a tabulated SFH defined in a file called ``sfh.dat``
-          that must reside in the data directory. The file must contain three
-          rows. The first column is time since the Big Bang in Gyr, the
-          second is the SFR in units of solar masses per year, the third is
-          the absolute metallicity. An example is provided in the data
+        * 2: Compute a tabulated SFH defined in a file called ``sfh.dat`` that
+          must reside in the data directory. The file must contain three
+          rows. The first column is time since the Big Bang in Gyr, the second
+          is the SFR in units of solar masses per year, the third is the
+          absolute metallicity. An example is provided in the data
           directory. The time grid in this file can be arbitrary (so long as
           the units are correct), but it is up to the user to ensure that the
           tabulated SFH is well-sampled so that the outputs are stable.
-          Obviously, highly oscillatory data require dense sampling.
+          Obviously, highly oscillatory data require dense sampling.  This
+          option is not supported in Python-FSPS.
         * 4: Delayed tau-model. This is the same as option 1 except that the
           tau-model component takes the form :math:`t\,e^{−t/\\tau}`.
 
@@ -350,9 +339,9 @@ class StellarPopulation(object):
         Compute SSPs for only the given evolutionary type.
 
     :param sigma_smooth: (default: 0.0)
-        If smooth_velocity is True, this gives the velocity dispersion in
-        km/s.  Otherwise, it gives the width of the gaussian wavelength
-        smoothing in Angstroms.
+        If smooth_velocity is True, this gives the velocity dispersion in km/s.
+        Otherwise, it gives the width of the gaussian wavelength smoothing in
+        Angstroms.  These widths are in terms of :math:`\sigma`, *not* FWHM.
 
     :param agb_dust: (default: 1.0)
         Scales the circumstellar AGB dust emission.
@@ -364,15 +353,15 @@ class StellarPopulation(object):
         Maximum wavelength to consider when smoothing the spectrum.
 
     :param gas_logu: (default: -2)
-        Log of the gas ionization parameter, for determining the
-        nebular emission.
- 
+        Log of the gas ionization parameter, for determining the nebular
+        emission.
+
     :param gas_logz: (default: 0.0)
-        Log of the gas-phase metallicity, for determining the nebular
-        emission.  In units of log10(Z/Z_sun).
+        Log of the gas-phase metallicity, for determining the nebular emission.
+        In units of :math:`\log (Z/Z_\odot)`.
 
     :param igm_factor: (default: 1.0)
-        Fudge factor used to scale the IGM optical depth.
+        Factor used to scale the IGM optical depth.
     """
 
     def __init__(self, compute_vega_mags=False, zcontinuous=0,
@@ -458,11 +447,10 @@ class StellarPopulation(object):
         # run the ``setup`` method.
         if not driver.is_setup:
             driver.setup(compute_vega_mags)
-
         else:
             cvms = driver.get_setup_vars()
             assert compute_vega_mags == bool(cvms)
-            
+
         self._zcontinuous = zcontinuous
         # Caching.
         self._wavelengths = None
@@ -485,21 +473,21 @@ class StellarPopulation(object):
         NSPEC = driver.get_nspec()
         NTFULL = driver.get_ntfull()
         driver.compute_zdep(NSPEC, NTFULL, self._zcontinuous)
-                
+
         self._stats = None
 
     def get_spectrum(self, zmet=None, tage=0.0, peraa=False):
         """
-        A grid (in age) of the spectra for the current CSP.
+        Return spectra for the current CSP.
 
         :param zmet: (default: None)
             The (integer) index of the metallicity to use. By default, use
             the current value of ``self.params["zmet"]``.
 
         :param tage: (default: 0.0)
-            The age of the stellar population. By default, this will compute
-            a grid of ages from :math:`t \approx 0` to the maximum age in the
-            isochrones.
+            The age of the stellar population for which to obtain a spectrum. By
+            default, this will compute a grid of ages from :math:`t \\approx 0`
+            to the maximum age in the isochrones.
 
         :param peraa: (default: False)
             If ``True``, return the spectrum in :math:`L_\odot/\AA`.
@@ -514,7 +502,6 @@ class StellarPopulation(object):
             If an age was provided by the ``tage`` parameter then the result
             is a 1D array with ``NSPEC`` values. Otherwise, it is a 2D array
             with shape ``(NTFULL, NSPEC)``.
-
         """
         self.params["tage"] = tage
         if zmet is not None:
@@ -533,7 +520,7 @@ class StellarPopulation(object):
         NSPEC = driver.get_nspec()
         if tage > 0.0:
             return wavegrid, driver.get_spec(NSPEC, 1)[0] * factor
-        
+
         NTFULL = driver.get_ntfull()
         return wavegrid, driver.get_spec(NSPEC, NTFULL) * factor[None, :]
 
@@ -561,26 +548,24 @@ class StellarPopulation(object):
         :returns mags:
             The magnitude grid. If an age was was provided by the ``tage``
             parameter then the result is a 1D array with ``NBANDS`` values.
-            Otherwise, it is a 2D array with shape ``(NTFULL, NBANDS)``. If
-            a particular set of bands was requested then this return value
-            will be properly compressed along that axis, ordered according
-            to the ``bands`` argument.
-
+            Otherwise, it is a 2D array with shape ``(NTFULL, NBANDS)``. If a
+            particular set of bands was requested then this return value will
+            be properly compressed along that axis, ordered according to the
+            ``bands`` argument.
         """
         self.params["tage"] = tage
         if zmet is not None:
             self.params["zmet"] = zmet
-        
+
         if self.params.dirty:
             self._compute_csp()
-        
+
         if tage > 0.0:
             NTFULL = 1
         else:
             NTFULL = driver.get_ntfull()
         NBANDS = driver.get_nbands()
         NSPEC = driver.get_nspec()
-        
         band_array = np.ones(NBANDS, dtype=bool)
         if bands is not None:
             user_sorted_inds = np.array([FILTERS[band.lower()].index
@@ -604,13 +589,14 @@ class StellarPopulation(object):
                 return mags
 
     def ztinterp(self, zpos, tpos, peraa=False):
-        """Return an SSP spectrum, mass, and luminosity interpolated
-        to a target metallicity and age.  This effectively wraps the
-        ZTINTERP subroutine.  Only the SSPs bracketing a given
-        metallicity will be regenerated, if parameters are dirty.
+        """
+        Return an SSP spectrum, mass, and luminosity interpolated to a target
+        metallicity and age.  This effectively wraps the ZTINTERP subroutine.
+        Only the SSPs bracketing a given metallicity will be regenerated, if
+        parameters are dirty.
 
         :param zpos:
-            The metallicity, in units of :math:`log(Z/Z_\odot)`
+            The metallicity, in units of :math:`\log(Z/Z_\odot)`
 
         :param tpos:
             The desired age, in Gyr.
@@ -644,12 +630,13 @@ class StellarPopulation(object):
         return spec, mass, lbol
 
     def _all_ssp_spec(self, update=True, peraa=False):
-        """Return the contents of the ssp_spec_zz array.
+        """
+        Return the contents of the ssp_spec_zz array.
 
         :param update: (default: True)
-            If True, forces an update of the SSPs if the ssp
-            parameters have changed. Otherwise simply dumps the
-            current contents of the ``ssp_spec_zz`` array.
+            If True, forces an update of the SSPs if the ssp parameters have
+            changed. Otherwise simply dumps the current contents of the
+            ``ssp_spec_zz`` array.
 
         :param peraa: (default: False)
             If true, return spectra in units of :math:`L_\odot/\AA`, otherwise
@@ -662,8 +649,7 @@ class StellarPopulation(object):
             The mass of the SSPs, having shape (ntfull, nz).
 
         :returns lbol:
-            The bolometric luminosity of the SSPs, having shape
-            (ntfull, nz).
+            The bolometric luminosity of the SSPs, having shape (ntfull, nz).
         """
 
         if (self.params.dirtiness == 2) and update:
@@ -686,13 +672,13 @@ class StellarPopulation(object):
 
     def get_stellar_spectrum(self, mact, logt, lbol, logg, phase, comp,
                              mdot=0, weight=1, zmet=None, peraa=True):
-        """Get the spectrum of a star with a given set of physical
-        parameters.  This uses the metallicity given by the
-        current value of ``zmet``.
+        """
+        Get the spectrum of a star with a given set of physical parameters.
+        This uses the metallicity given by the current value of ``zmet``.
 
         :param mact:
-            Actual stellar mass (after taking into account mass loss).
-            Used to calculate surface gravity.
+            Actual stellar mass (after taking into account mass loss).  Used to
+            calculate surface gravity.
 
         :param logt:
             The log of the effective temperature.
@@ -701,17 +687,17 @@ class StellarPopulation(object):
             Stellar luminosity, in units of :math:`L_\odot`
 
         :param logg:
-            Log of the surface gravity g.  Note that this variable is
-            actually ignored, and logg is calculated internally using
-            ``mact``, ``lbol``, and ``logt``.
+            Log of the surface gravity g.  Note that this variable is actually
+            ignored, and logg is calculated internally using ``mact``,
+            ``lbol``, and ``logt``.
 
         :param phase:
             The evolutionary phase, 0 through 6.
 
         :param comp:
-            Composition, in terms of C/O ratio.  Only used for AGB
-            stars (phase=5), where the division between carbon and
-            oxyygen rich stars is C/O = 1.
+            Composition, in terms of C/O ratio.  Only used for AGB stars
+            (phase=5), where the division between carbon and oxyygen rich stars
+            is :math:`C/O = 1`.
 
         :param mdot:
             The log of the mass loss rate.
@@ -730,53 +716,54 @@ class StellarPopulation(object):
 
         NSPEC = driver.get_nspec()
         outspec = np.zeros(NSPEC)
-        driver.stellar_spectrum(mact, logt, lbol, logg, phase, comp, mdot, weight, outspec)
+        driver.stellar_spectrum(mact, logt, lbol, logg, phase,
+                                comp, mdot, weight, outspec)
         if peraa:
             wavegrid = self.wavelengths
             factor = 3e18 / wavegrid ** 2
             outspec *= factor
 
         return outspec
-    
-    def isochrones(self, outfile = 'pyfsps_tmp'):
-        """Write the isochrone data (age, mass, weights, phases,
-        magnitudes, etc.)  to a .cmd file, then read it into a huge
-        numpy array.
+
+    def isochrones(self, outfile='pyfsps_tmp'):
+        """
+        Write the isochrone data (age, mass, weights, phases, magnitudes, etc.)
+        to a .cmd file, then read it into a huge numpy array.
 
         :param outfile: (default: 'pyfsps_tmp')
-            The file root name of the .cmd file, which will be placed
-            in the $SPS_HOME/OUTPUTS/ directory
-            
+            The file root name of the .cmd file, which will be placed in the
+            $SPS_HOME/OUTPUTS/ directory
+
         :returns dat:
-            A huge numpy array containing information about every
-            isochrone point for the current metallicity.
-            
+            A huge numpy array containing information about every isochrone
+            point for the current metallicity.
+
         :returns header:
-            A list of the column names pulled from the header of the
-            .cmd file.  The number of column names will not match the
-            number of columns in dat since there are as many ``mags``
-            as filters.  Use ``fsps.list_filters()`` to get the ordered
-            filter name list.
+            A list of the column names pulled from the header of the .cmd file.
+            The number of column names will not match the number of columns in
+            dat since there are as many ``mags`` as filters.  Use
+            ``fsps.list_filters()`` to get the ordered filter name list.
         """
         if self.params.dirty:
             self._compute_csp()
-            
+
         from . import ev, list_filters
-        absfile = os.path.join(ev,'OUTPUTS',outfile+'.cmd')
+        absfile = os.path.join(ev, 'OUTPUTS', outfile+'.cmd')
         driver.write_isoc(outfile)
-        
+
         with open(absfile, 'r') as f:
-            header = f.readline().split()[1:-1] #drop the comment hash and mags field
+            # drop the comment hash and mags field
+            header = f.readline().split()[1:-1]
         header += list_filters()
         cmd_data = np.loadtxt(absfile, comments='#',
                               dtype=np.dtype([(n, np.float) for n in header]))
         return cmd_data
-            
+
     def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
-        """Smooth a spectrum by a gaussian with standard deviation
-        given by sigma.  Whether the smoothing is in velocity space or
-        in wavelength space depends on the value of the value of
-        smooth_velocity.
+        """
+        Smooth a spectrum by a gaussian with standard deviation given by sigma.
+        Whether the smoothing is in velocity space or in wavelength space
+        depends on the value of the value of smooth_velocity.
 
         :param wave:
             The input wavelength grid.
@@ -855,8 +842,8 @@ class StellarPopulation(object):
 
     @property
     def stellar_mass(self):
-        """Stellar mass (including remants if the FSPS parameters
-        `add_stellar_remants=1`) in solar masses.
+        """Stellar mass in solar masses (including remants if the FSPS
+        parameter `add_stellar_remants=1`).
         """
         return self._stat(1)
 
@@ -894,9 +881,10 @@ class StellarPopulation(object):
 class ParameterSet(object):
 
     ssp_params = ["imf_type", "imf1", "imf2", "imf3", "vdmc", "mdave",
-                  "dell", "delt", "sbss", "fbhb", "pagb", "add_stellar_remnants",
-                  "tpagb_norm_type", "add_agb_dust_model", "agb_dust",
-                  "redgb", "masscut", "fcstar", "evtype"]
+                  "dell", "delt", "sbss", "fbhb", "pagb",
+                  "add_stellar_remnants", "tpagb_norm_type",
+                  "add_agb_dust_model", "agb_dust", "redgb", "masscut",
+                  "fcstar", "evtype"]
 
     csp_params = ["smooth_velocity", "vactoair_flag", "redshift_colors",
                   "dust_type", "add_dust_emission", "add_neb_emission",

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -537,47 +537,6 @@ class StellarPopulation(object):
         NTFULL = driver.get_ntfull()
         return wavegrid, driver.get_spec(NSPEC, NTFULL) * factor[None, :]
 
-    @property
-    def wavelengths(self):
-        """
-        The wavelength scale for the computed spectra, in :math:`\AA`
-
-        """
-        if self._wavelengths is None:
-            NSPEC = driver.get_nspec()
-            self._wavelengths = driver.get_lambda(NSPEC)
-        return self._wavelengths
-
-    @property
-    def zlegend(self):
-        """
-        The available metallicities.
-
-        """
-        if self._zlegend is None:
-            NZ = driver.get_nz()
-            self._zlegend = driver.get_zlegend(NZ)
-        return self._zlegend
-
-    @property
-    def ssp_ages(self):
-        """
-        The age grid of the SSPs, in log(years), used by FSPS.
-
-        """
-        if self._ssp_ages is None:
-            NTFULL = driver.get_ntfull()
-            self._ssp_ages = driver.get_timefull(NTFULL)
-        return self._ssp_ages
-
-    def filter_data(self):
-        """Return effective wavelengths, and vega and solar magnitudes
-        of all filters.
-        """
-        NBANDS = driver.get_nbands()
-        lambda_eff, magvega, magsun = driver.get_filter_data(NBANDS)
-        return lambda_eff, magvega, magsun
-
     def get_mags(self, zmet=None, tage=0.0, redshift=0.0, bands=None):
         """
         Get the magnitude of the CSP.
@@ -684,7 +643,7 @@ class StellarPopulation(object):
 
         return spec, mass, lbol
 
-    def all_ssp_spec(self, update=True, peraa=False):
+    def _all_ssp_spec(self, update=True, peraa=False):
         """Return the contents of the ssp_spec_zz array.
 
         :param update: (default: True)
@@ -724,41 +683,6 @@ class StellarPopulation(object):
             spec *= factor[:, None, None]
 
         return spec, mass, lbol
-
-    def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
-        """Smooth a spectrum by a gaussian with standard deviation
-        given by sigma.  Whether the smoothing is in velocity space or
-        in wavelength space depends on the value of the value of
-        smooth_velocity.
-
-        :param wave:
-            The input wavelength grid.
-
-        :param spec:
-            The input spectrum.
-
-        :param sigma:
-            The standard deviation of the gaussian broadening function.
-
-        :param minw:
-            Optionally set the minimum wavelength to consider when
-            broadening.
-
-        :param maxw:
-            Optionally set the maximum wavelength to consider when
-            broadening.
-
-        :returns outspec:
-            The smoothed spectrum, on the same wavelength grid as the input.
-        """
-        if maxw is None:
-            maxw = np.max(wave)
-        if minw is None:
-            minw = np.min(wave)
-        assert len(wave) == len(spec)
-        outspec = np.array(spec)
-        driver.smooth_spectrum(wave, outspec, sigma, minw, maxw)
-        return outspec
 
     def get_stellar_spectrum(self, mact, logt, lbol, logg, phase, comp,
                              mdot=0, weight=1, zmet=None, peraa=True):
@@ -848,6 +772,82 @@ class StellarPopulation(object):
                               dtype=np.dtype([(n, np.float) for n in header]))
         return cmd_data
             
+    def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
+        """Smooth a spectrum by a gaussian with standard deviation
+        given by sigma.  Whether the smoothing is in velocity space or
+        in wavelength space depends on the value of the value of
+        smooth_velocity.
+
+        :param wave:
+            The input wavelength grid.
+
+        :param spec:
+            The input spectrum.
+
+        :param sigma:
+            The standard deviation of the gaussian broadening function.
+
+        :param minw:
+            Optionally set the minimum wavelength to consider when
+            broadening.
+
+        :param maxw:
+            Optionally set the maximum wavelength to consider when
+            broadening.
+
+        :returns outspec:
+            The smoothed spectrum, on the same wavelength grid as the input.
+        """
+        if maxw is None:
+            maxw = np.max(wave)
+        if minw is None:
+            minw = np.min(wave)
+        assert len(wave) == len(spec)
+        outspec = np.array(spec)
+        driver.smooth_spectrum(wave, outspec, sigma, minw, maxw)
+        return outspec
+
+    def filter_data(self):
+        """Return effective wavelengths, and vega and solar magnitudes
+        of all filters.
+        """
+        NBANDS = driver.get_nbands()
+        lambda_eff, magvega, magsun = driver.get_filter_data(NBANDS)
+        return lambda_eff, magvega, magsun
+
+    @property
+    def wavelengths(self):
+        """
+        The wavelength scale for the computed spectra, in :math:`\AA`
+
+        """
+        if self._wavelengths is None:
+            NSPEC = driver.get_nspec()
+            self._wavelengths = driver.get_lambda(NSPEC)
+        return self._wavelengths
+
+    @property
+    def zlegend(self):
+        """
+        The available metallicities.
+
+        """
+        if self._zlegend is None:
+            NZ = driver.get_nz()
+            self._zlegend = driver.get_zlegend(NZ)
+        return self._zlegend
+
+    @property
+    def ssp_ages(self):
+        """
+        The age grid of the SSPs, in log(years), used by FSPS.
+
+        """
+        if self._ssp_ages is None:
+            NTFULL = driver.get_ntfull()
+            self._ssp_ages = driver.get_timefull(NTFULL)
+        return self._ssp_ages
+
     @property
     def log_age(self):
         """log10(age/yr)."""


### PR DESCRIPTION
This pull request makes changes to documentation strings to make better webpages and be more up to date.  There are also numerous PEP8 style fixes. This PR also changes the ordering of functions in the fsps module and the Fortran bindings to make more logical sections.  Some unused suboroutines and functions are removed.

This is likely to cause conflicts with unmerged branches, because of the function reordering.  It doesn't look like there are many outstanding branches though.