### PR TITLE
handle blank lines in FILTER_LIST

### DIFF
--- a/fsps/filters.py
+++ b/fsps/filters.py
@@ -137,7 +137,10 @@ def _load_filter_dict():
     with open(filter_list_path) as f:
         for line in f:
             columns = line.strip().split()
-            fsps_id, key = columns[:2]
+            if len(columns) > 1
+                fsps_id, key = columns[:2]
+            else:
+                continue
             comment = ' '.join(columns[2:])
             filters[key.lower()] = Filter(int(fsps_id), key, comment)
 


### PR DESCRIPTION
The addition of filters to FSPS sometimes results in empty, blank lines in `$SPS_HOME/data/FILTER_LIST`, which prevents python-FSPS from building.  This PR tests for blank lines and skips them when building the filter dictionary.
