### PR TITLE
Add AGN related parameters introduced to fsps in commit a23e409cdc4.

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -32,7 +32,7 @@ except KeyError:
 
 # Check the githashes to make sure the required FSPS updates are
 # present, and if not or there are no githashes, raise an error
-REQUIRED_GITHASHES = ['6ad1058\n', 'b5250ab\n']
+REQUIRED_GITHASHES = ['6ad1058\n', 'b5250ab\n', 'a23e409\n']
 
 cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
 stat, githashes, err = run_command(cmd)

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -85,8 +85,8 @@ contains
                             dust_index,dust_tesc,frac_obrun,uvb,mwr,&
                             dust1_index,sf_start,sf_trunc,sf_slope,&
                             duste_gamma,duste_umin,duste_qpah,&
-                            sigma_smooth,min_wave_smooth,&
-                            max_wave_smooth,gas_logu,gas_logz,igm_factor)
+                            sigma_smooth,min_wave_smooth,max_wave_smooth,&
+                            gas_logu,gas_logz,igm_factor,fagn,agn_tau)
 
     ! Set all the parameters that don't affect the SSP computation.
 
@@ -102,8 +102,8 @@ contains
                             dust_index,dust_tesc,frac_obrun,uvb,mwr,&
                             dust1_index,sf_start,sf_trunc,sf_slope,&
                             duste_gamma,duste_umin,duste_qpah,&
-                            sigma_smooth,min_wave_smooth,&
-                            max_wave_smooth,gas_logu,gas_logz,igm_factor
+                            sigma_smooth,min_wave_smooth,max_wave_smooth,&
+                            gas_logu,gas_logz,igm_factor,fagn,agn_tau
 
     smooth_velocity=smooth_velocity0
     vactoair_flag=vactoair_flag0
@@ -151,6 +151,8 @@ contains
     pset%gas_logu=gas_logu
     pset%gas_logz=gas_logz
     pset%igm_factor=igm_factor
+    pset%fagn=fagn
+    pset%agn_tau=agn_tau
     
   end subroutine
 

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -362,6 +362,16 @@ class StellarPopulation(object):
 
     :param igm_factor: (default: 1.0)
         Factor used to scale the IGM optical depth.
+
+    :param fagn: (default: 0.0)
+        The total luminosity of the AGN, expressed as a fraction of the
+        bolometric stellar luminosity (so it can be greater than 1). The shape
+        of the AGN SED is from the Nenkova et al. 2008 templates.
+
+    :param agn_tau: (default: 10)
+        Optical depth of the AGN dust torus, which affects the shape of the AGN
+        SED.  Outside the range (5, 150) the AGN SED is an
+        extrapolation.
     """
 
     def __init__(self, compute_vega_mags=False, zcontinuous=0,
@@ -432,6 +442,8 @@ class StellarPopulation(object):
             gas_logu=-2,
             gas_logz=0.0,
             igm_factor=1.0,
+            fagn=0.0,
+            agn_tau=10.0
         )
 
         # Parse any input options.
@@ -897,7 +909,7 @@ class ParameterSet(object):
                   "sf_start", "sf_trunc", "sf_slope", "duste_gamma",
                   "duste_umin", "duste_qpah", "sigma_smooth",
                   "min_wave_smooth", "max_wave_smooth", "gas_logu",
-                  "gas_logz", "igm_factor"]
+                  "gas_logz", "igm_factor", "fagn", "agn_tau"]
 
     @property
     def all_params(self):


### PR DESCRIPTION
In cconroy20/fsps@a23e409cdc4 the Nenkova 2008 AGN templates were added as an optional component of the SED.  This PR adds python-FSPS support for the AGN related parameters `fagn` and `agn_tau`.  The relevant FSPS githash is added to the required list.