### PR TITLE
Vac and mags

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,12 @@ License
 *Copyright 2013-2016 Dan Foreman-Mackey and contributors.*
 
 These bindings are available under the `MIT License
-<https://raw.github.com/dfm/python-fsps/master/LICENSE.rst>`_. See the `FSPS
-homepage <https://github.com/cconroy20/fsps>`_ for usage
+<https://raw.github.com/dfm/python-fsps/master/LICENSE.rst>`_.
+
+If you make use of this code, please reference these Python bindings,
+
+.. image:: http://img.shields.io/badge/DOI-10.5281/zenodo.12157-blue.svg?style=flat
+  :target: http://dx.doi.org/10.5281/zenodo.12157
+
+and see the `FSPS homepage <https://github.com/cconroy20/fsps>`_ for additional usage
 restrictions and citation requirements.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,10 +21,6 @@ These bindings rely on the value of the ``SPS_HOME`` environment
 variable being correctly set and the compiled ``.o`` and ``.mod``
 files being available in the ``${SPS_HOME}/src`` directory.
 
-Python-FSPS is developed using python2.7.  We have attempted to maintain
-python3 compatability, but if you encounter compatibility problems, please open
-an issue on `GitHub <https://github.com/dfm/python-fsps>`_.
-
 Installing development version
 ------------------------------
 

--- a/docs/stellarpop_api.rst
+++ b/docs/stellarpop_api.rst
@@ -1,7 +1,7 @@
 Modelling Stellar Populations
 =============================
 
-:class:`fsps.StellarPopulation` drives FSPS and is generally the only API needed.
+:class:`fsps.StellarPopulation` drives FSPS and is generally the only API needed. 
 :func:`fsps.find_filter` can also be used interactively to search for a filter (see also :doc:`filters`).
 
 Example
@@ -31,6 +31,7 @@ We can also get the spectrum, here in units of :math:`L_\odot/\mathrm{Hz}`::
 
    >>> wave, spec = sp.get_spectrum(tage=13.7)
 
+ It is highly recemmended that only one instance of :class:`fsps.StellarPopulation` be used in a given program.
 
 API Reference
 -------------

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -21,16 +21,17 @@ module driver
   
 contains
 
-  subroutine setup(compute_vega_mags0)
+  subroutine setup(compute_vega_mags0, vactoair_flag0)
 
     ! Load all the data files/templates into memory.
 
     implicit none
 
-    integer, intent(in) :: compute_vega_mags0
+    integer, intent(in) :: compute_vega_mags0, vactoair_flag0
          
 
     compute_vega_mags = compute_vega_mags0
+    vactoair_flag = vactoair_flag0
     call sps_setup(-1)
     is_setup = 1
 
@@ -76,7 +77,7 @@ contains
     
   end subroutine
 
-  subroutine set_csp_params(smooth_velocity0,vactoair_flag0,redshift_colors0,&
+  subroutine set_csp_params(smooth_velocity0,redshift_colors0,&
                             dust_type0,add_dust_emission0,add_neb_emission0,&
                             add_neb_continuum0,cloudy_dust0,add_igm_absorption0,&
                             zmet,sfh,wgp1,wgp2,wgp3,tau,&
@@ -92,7 +93,7 @@ contains
 
     implicit none
     
-    integer, intent(in) :: smooth_velocity0,vactoair_flag0,redshift_colors0,&
+    integer, intent(in) :: smooth_velocity0,redshift_colors0,&
                            dust_type0,add_dust_emission0,add_neb_emission0,&
                            add_neb_continuum0,cloudy_dust0,add_igm_absorption0,&
                            zmet,sfh,wgp1,wgp2,wgp3
@@ -106,7 +107,6 @@ contains
                             gas_logu,gas_logz,igm_factor,fagn,agn_tau
 
     smooth_velocity=smooth_velocity0
-    vactoair_flag=vactoair_flag0
     redshift_colors=redshift_colors0
     dust_type=dust_type0
     add_dust_emission=add_dust_emission0
@@ -356,11 +356,12 @@ contains
 
   end subroutine
   
-  subroutine get_setup_vars(cvms)
+  subroutine get_setup_vars(cvms, vta_flag)
 
     implicit none
-    integer, intent(out) :: cvms
+    integer, intent(out) :: cvms, vta_flag
     cvms = compute_vega_mags
+    vta_flag = vactoair_flag
 
   end subroutine
 
@@ -428,8 +429,12 @@ contains
     implicit none
     integer, intent(in) :: ns
     double precision, dimension(ns), intent(out) :: lambda
-    lambda = spec_lambda
-
+    if (vactoair_flag .eq. 1) then
+       lambda = vactoair(spec_lambda)
+    else
+       lambda = spec_lambda
+    endif
+    
   end subroutine
 
   subroutine get_isochrone_dimensions(n_age,n_mass)

--- a/fsps/tests.py
+++ b/fsps/tests.py
@@ -88,8 +88,6 @@ def test_csp():
     wave, spec = pop.get_spectrum(tage=1.0)
     pop.params["tau"] = 3.0
     assert pop.params.dirtiness == 1
-    pop.params["sfh"] = 0
-    pop.params["tau"] = 1.0
 
 
 def test_redshift():
@@ -108,8 +106,4 @@ def test_redshift():
     # The following fails for now, because of how redshifting and filter projection is
     # delegated in and accessed from FSPS.  The difference will be dist. mod. - 2.5*log(1+zred)
 
-    # assert np.all(v3 == v1)
-
-    v5 = pop.get_mags(redshift=1.0, tage=1.0, bands=["v"])
-    assert np.all(v5 != v4)
-    
+    # assert np.all(v3 == v1)    


### PR DESCRIPTION
In order for vactoair to actually do something and in a consistent way, I've made it a setup parameter.  

I also changed get_mags to raise an error if both `zred` and `redshift` are non-zero, as this causes the spectrum to get redshifted twice.  More documentation about the units of mags is given.