### PR TITLE
Tabular SFHs

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -355,6 +355,20 @@ contains
     ssp_lbol_out = lbol_ssp_zz
 
   end subroutine
+
+  subroutine set_sfh_tab(ntab, age, sfr, met)
+
+    ! Fill the sfh_tab array
+
+    implicit none
+    integer, intent(in) :: ntab
+    double precision, dimension(ntab), intent(in) :: age, sfr, met
+    ntabsfh = ntab
+    sfh_tab(1,1:ntabsfh) = age
+    sfh_tab(2, 1:ntabsfh) = sfr
+    sfh_tab(3, 1:ntabsfh) = met
+
+  end subroutine set_sfh_tab
   
   subroutine get_setup_vars(cvms, vta_flag)
 

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -531,7 +531,7 @@ class StellarPopulation(object):
             factor = np.ones_like(wavegrid)
 
         NSPEC = driver.get_nspec()
-        if tage > 0.0:
+        if (tage > 0.0) or (tage == -99):
             return wavegrid, driver.get_spec(NSPEC, 1)[0] * factor
 
         NTFULL = driver.get_ntfull()
@@ -780,6 +780,37 @@ class StellarPopulation(object):
                               dtype=np.dtype([(n, np.float) for n in header]))
         return cmd_data
 
+    def set_tabular_sfh(self, age, sfr, Z=None):
+        """Set a tabular SFH for use with the sfh=3 option.  See the FSPS
+        documentation for information about tabular SFHs.  This SFH will be
+        piecewise linearly interpolated.
+
+        :param age:
+            Age in Gyr.  ndarray of shape (ntab,)
+
+        :param sfr:
+            The SFR at each ``age``, in Msun/yr.  Must be an ndarray same
+            length as ``age``.
+
+        :param Z: (optional)
+            The metallicity at each age.  Currently this is ignored, and the
+            value of ``zmet`` or ``logzsol`` is used for all ages.  Thus
+            setting this parameter will result in a NotImplementedError.
+        """
+        assert len(age) == len(sfr)
+        ntab = len(age)
+        if Z is None:
+            Z = np.zeros(ntab)
+        else:
+            raise(NotImplementedError)
+            assert len(Z) == ntab
+        driver.set_sfh_tab(age*1e9, sfr, Z)
+        if self.params['sfh'] == 3:
+            self.params.dirtiness = max(1, self.params.dirtiness)
+        else:
+            print("Warning: You are setting a tabular SFH, "
+                  "but but the ``sfh`` parameter is not 3")
+    
     def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
         """
         Smooth a spectrum by a gaussian with standard deviation given by sigma.

--- a/fsps/tests.py
+++ b/fsps/tests.py
@@ -106,4 +106,27 @@ def test_redshift():
     # The following fails for now, because of how redshifting and filter projection is
     # delegated in and accessed from FSPS.  The difference will be dist. mod. - 2.5*log(1+zred)
 
-    # assert np.all(v3 == v1)    
+    # assert np.all(v3 == v1)
+
+def test_tabular():
+    _reset_default_params()
+
+    import os
+    fn = os.path.join(os.environ['SPS_HOME'], 'data/sfh.dat')
+    age, sfr, z = np.genfromtxt(fn, unpack=True, skip_header=0)
+
+    pop.params['sfh'] = 3
+    pop.set_tabular_sfh(age, sfr)
+    w, spec = pop.get_spectrum(tage=0)
+    pop.set_tabular_sfh(age, sfr)
+    assert pop.params.dirty
+    w, spec = pop.get_spectrum(tage=0)
+    assert spec.shape[0] == len(pop.ssp_ages)
+    assert pop.params['sfh'] == 3
+    w, spec_last = pop.get_spectrum(tage=-99)
+    assert spec_last.ndim == 1
+    w, spec = pop.get_spectrum(tage=age.max())
+    assert np.allclose(spec, spec_last)
+    pop.params['logzsol'] = -1
+    w, spec_lowz = pop.get_spectrum(tage=age.max())
+    assert not np.allclose(spec, spec_lowz)


### PR DESCRIPTION
This PR adds support for tabular SFHs (SFH option 3) by adding a new method, ``set_tabular_sfh``.  Usage is e.g.
```
import numpy as np
import fsps
sps = fsps.StellarPopulation()
sps.params['sfh'] = 3
age = np.linspace(1, 10, 50)
sfr = np.exp(-age/3.0)
sps.set_tabular_sfh(age, sfr)
wave, spec = sps.get_spectrum(tage=0)
```
Setting ``tage=-99`` will calculate the spectrum only at the oldest age, as described in the FSPS docs.  Any value ``0 < tage <= age.max()`` will compute a single spectrum at that age, as usual.

A corresponding test is also included, which requires cconroy20/fsps@a211e64fa3ba or later for the tage=-99 option to work properly.