### PR TITLE
Update API example.

### DIFF
--- a/docs/stellarpop_api.rst
+++ b/docs/stellarpop_api.rst
@@ -1,37 +1,49 @@
 Modelling Stellar Populations
 =============================
 
-:class:`fsps.StellarPopulation` drives FSPS and is generally the only API needed. 
+:class:`fsps.StellarPopulation` drives FSPS and is generally the only API needed.
 :func:`fsps.find_filter` can also be used interactively to search for a filter (see also :doc:`filters`).
 
 Example
 -------
 
-Lets start by initializing a simple stellar population, born with solar metallicity 6 Gyr after the Big Bang, and some dust with a Calzetti et al (2000) extinction curve::
+Lets start by initializing a simple stellar population,
+with solar metallicity,
+and some dust with a Calzetti et al (2000) extinction curve::
 
    >>> import fsps
-   >>> sp = fsps.StellarPopulation(compute_vega_mags=False, sfh=0, zmet=20,
-                                   dust_type=2, dust2=0.2, sf_start=6.)
+   >>> sp = fsps.StellarPopulation(compute_vega_mags=False, zcontinuous=1,
+                                   sfh=0, logzsol=0.0, dust_type=2, dust2=0.2)
+   >>> sp.libraries()
+   ('pdva', 'miles')
 
-Lets get the AB magnitudes in SDSS bands, when the SSP has evolved to 13.7 Gyr after the Big Bang::
+The last line indicates that we are using the Padova isochrones and MILES spectral library.
+These can be changed only within FSPS itself (which must recompiled and python-FSPS reinstalled for the changes to take effect.)
+Let's get the AB magnitudes in SDSS bands, for an SSP that is 13.7 Gyr old::
 
    >>> sdss_bands = fsps.find_filter('sdss')
    >>> print(sdss_bands)
    ['sdss_u', 'sdss_g', 'sdss_i', 'sdss_r', 'sdss_z']
    >>> sp.get_mags(tage=13.7, bands=sdss_bands)
-   array([ 9.83712169,  7.89895578,  6.58329011,  6.9877158 ,  6.21844951])
+   array([ 9.85484694,  7.8785663 ,  6.56580511,  6.99828574,  6.16779663])
 
 Now we can change a parameter (say, lower the metallicity) and get a new set of magnitudes::
 
-   >>> sp.params['zmet'] = 10
+   >>> sp.params['logzsol'] = -1
    >>> sp.get_mags(tage=13.7, bands=sdss_bands)
-   array([ 8.56374292,  7.12518721,  6.14903857,  6.43916996,  5.9635293 ])
+   array([ 8.5626572 ,  7.07918435,  6.05304881,  6.38592117,  5.84199   ])
 
-We can also get the spectrum, here in units of :math:`L_\odot/\mathrm{Hz}`::
+We can also get the spectrum, here in units of :math:`L_\odot/\mathrm{Hz}`,
+the total stellar mass formed by 13.7 Gyr,
+and the surviving stellar mass at 13.7 Gyr (both in units of :math:`M_\odot`)::
 
    >>> wave, spec = sp.get_spectrum(tage=13.7)
+   >>> sp.formed_mass
+   1.0
+   >>> sp.stellar_mass
+   0.57809244144339011
 
- It is highly recemmended that only one instance of :class:`fsps.StellarPopulation` be used in a given program.
+ It is highly recommended that only one instance of :class:`fsps.StellarPopulation` be used in a given program.
 
 API Reference
 -------------


### PR DESCRIPTION
This PR updates the StellarPopulation API example to remove the incorrect statements about `sf_start` with `sfh=0`, to use `zcontinuous` and `logzsol` instead of zmet (which depends on the isochrones being used), and to show a little more functionality that might help users interpret the output and cut down on issue reporting.