### PR TITLE
Smooth lsf

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -372,6 +372,20 @@ contains
     sfh_tab(3, 1:ntabsfh) = met
 
   end subroutine set_sfh_tab
+
+  subroutine set_ssp_lsf(ns, sigma, wlo, whi)
+
+    ! Fill the lsfinfo structure
+
+    implicit none
+    integer, intent(in) :: ns
+    double precision, dimension(ns), intent(in) :: sigma
+    double precision, intent(in) :: wlo, whi
+    lsfinfo%minlam = wlo
+    lsfinfo%maxlam = whi
+    lsfinfo%lsf = sigma
+
+  end subroutine set_ssp_lsf
   
   subroutine get_setup_vars(cvms, vta_flag)
 

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -40,14 +40,14 @@ contains
   subroutine set_ssp_params(imf_type0,imf1,imf2,imf3,vdmc,mdave,dell,&
                             delt,sbss,fbhb,pagb,add_stellar_remnants0,&
                             tpagb_norm_type0,add_agb_dust_model0,agb_dust,&
-                            redgb,masscut,fcstar,evtype)
+                            redgb,masscut,fcstar,evtype,smooth_lsf0)
  
     ! Set the parameters that affect the SSP computation.
 
     implicit none
 
     integer, intent(in) :: imf_type0,add_stellar_remnants0,tpagb_norm_type0,&
-                           add_agb_dust_model0
+                           add_agb_dust_model0,smooth_lsf0
     double precision, intent(in) :: imf1,imf2,imf3,vdmc,mdave,dell,&
                                     delt,sbss,fbhb,pagb,agb_dust,&
                                     redgb,masscut,fcstar,evtype
@@ -56,6 +56,7 @@ contains
     add_stellar_remnants=add_stellar_remnants0
     tpagb_norm_type=tpagb_norm_type0
     add_agb_dust_model=add_agb_dust_model0
+    smooth_lsf=smooth_lsf0
     pset%imf1=imf1
     pset%imf2=imf2
     pset%imf3=imf3

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -35,6 +35,9 @@ contains
     call sps_setup(-1)
     is_setup = 1
 
+    ! We will only compute mags when asked for through get_mags.
+    pset%mag_compute=0
+
   end subroutine
 
   subroutine set_ssp_params(imf_type0,imf1,imf2,imf3,vdmc,mdave,dell,&

--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -377,13 +377,13 @@ contains
 
   end subroutine set_sfh_tab
 
-  subroutine set_ssp_lsf(ns, sigma, wlo, whi)
+  subroutine set_ssp_lsf(nsv, sigma, wlo, whi)
 
     ! Fill the lsfinfo structure
 
     implicit none
-    integer, intent(in) :: ns
-    double precision, dimension(ns), intent(in) :: sigma
+    integer, intent(in) :: nsv
+    double precision, dimension(nsv), intent(in) :: sigma
     double precision, intent(in) :: wlo, whi
     lsfinfo%minlam = wlo
     lsfinfo%maxlam = whi

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -826,8 +826,40 @@ class StellarPopulation(object):
             self.params.dirtiness = max(1, self.params.dirtiness)
         else:
             print("Warning: You are setting a tabular SFH, "
-                  "but but the ``sfh`` parameter is not 3")
+                  "but the ``sfh`` parameter is not 3")
 
+    def set_lsf(self, wave, sigma, wmin=None, wmax=None):
+        """
+        Set a wavelength dependent Gaussian line-spread function that will be
+        applied to the SSPs.
+
+        :param wave:
+            Wavelength in angstroms, sorted ascending.  If `wmin` or `wmax`
+            are not specified they are taken from the minimum and maximum of
+            this array.  ndarray.
+
+        :param sigma:
+            The dispersion of the Gaussian LSF at the wavelengths given by
+            `wave`, in km/s.  If 0, no smoothing is applied at that wavelength.
+            ndarray of same shape as `wave`.
+
+        :param wmin: (optional)
+            The minimum wavelength (in AA) for which smoothing will be
+            applied. If not given, it is taken from the minimum of `wave`.
+
+        :param wmax: (optional)
+            The maximum wavelength (in AA) for which smoothing will be
+            applied. If not given, it is taken from the maximum of `wave`.
+        """
+
+        if wmin is None:
+            wmin = wave.min()
+        if wmax is None:
+            wmax = wave.max()
+        sig = np.interp(self.wavelengths, wave, sigma)
+        driver.set_ssp_lsf(len(self.wavelengths), sig, wmin, wmax)
+        self.params.dirtiness = max(2, self.params.dirtiness)
+            
     def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
         """
         Smooth a spectrum by a gaussian with standard deviation given by sigma.

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -864,7 +864,7 @@ class StellarPopulation(object):
         if wmax is None:
             wmax = wave.max()
         sig = np.interp(self.wavelengths, wave, sigma)
-        driver.set_ssp_lsf(len(self.wavelengths), sig, wmin, wmax)
+        driver.set_ssp_lsf(sig, wmin, wmax)
         if self.params["smooth_lsf"]:
             self.params.dirtiness = max(2, self.params.dirtiness)
         else:

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -837,7 +837,8 @@ class StellarPopulation(object):
     def set_lsf(self, wave, sigma, wmin=None, wmax=None):
         """
         Set a wavelength dependent Gaussian line-spread function that will be
-        applied to the SSPs.
+        applied to the SSPs.  Only takes effect if ``smooth_lsf`` and
+        ``smooth_velocity`` are True.
 
         :param wave:
             Wavelength in angstroms, sorted ascending.  If `wmin` or `wmax`

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -96,6 +96,11 @@ class StellarPopulation(object):
         Switch to choose smoothing in velocity space (``True``) or wavelength
         space.
 
+    :param smooth_lsf: (default: False)
+        Switch to apply smoothing of the SSPs by a wavelength dependent line
+        spread function. See the ``set_lsf()`` method for details.  Only takes
+        effect if ``smooth_velocity`` is True.
+
     :param cloudy_dust: (default: False)
         Switch to include dust in the Cloudy tables.
 
@@ -405,6 +410,7 @@ class StellarPopulation(object):
             redshift_colors=False,
             compute_light_ages=False,
             smooth_velocity=True,
+            smooth_lsf=False,
             cloudy_dust=False,
             agb_dust=1.0,
             tpagb_norm_type=2,
@@ -858,8 +864,15 @@ class StellarPopulation(object):
             wmax = wave.max()
         sig = np.interp(self.wavelengths, wave, sigma)
         driver.set_ssp_lsf(len(self.wavelengths), sig, wmin, wmax)
-        self.params.dirtiness = max(2, self.params.dirtiness)
-            
+        if self.params["smooth_lsf"]:
+            self.params.dirtiness = max(2, self.params.dirtiness)
+        else:
+            print("Warning: You are setting an LSF for the SSPs, "
+                  "but the ``smooth_lsf`` parameter is not True.")
+        if (not self.params["smooth_velocity"]):
+            print("Warning: You are setting an LSF for the SSPs, "
+                  "but the ``smooth_velocity`` parameter is not True.")
+
     def smoothspec(self, wave, spec, sigma, minw=None, maxw=None):
         """
         Smooth a spectrum by a gaussian with standard deviation given by sigma.
@@ -1061,7 +1074,7 @@ class ParameterSet(object):
                   "dell", "delt", "sbss", "fbhb", "pagb",
                   "add_stellar_remnants", "tpagb_norm_type",
                   "add_agb_dust_model", "agb_dust", "redgb", "masscut",
-                  "fcstar", "evtype"]
+                  "fcstar", "evtype", "smooth_lsf"]
 
     csp_params = ["smooth_velocity", "redshift_colors",
                   "compute_light_ages",


### PR DESCRIPTION
This allows python access to the wavelength dependent line spread function smoothing of the SSPs in FSPS through the `smooth_lsf` parameter and the `set_lsf` method.  This way there is no dependence on the `$SPS_HOME/data/lsf.dat` file, which can be problematic if StellarPopulations are running in multiple python processes on the same machine.