### PR TITLE
AGB parameter and sfr_avg

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -44,7 +44,7 @@ contains
                             imf1,imf2,imf3,vdmc,mdave,dell,&
                             delt,sbss,fbhb,pagb,add_stellar_remnants0,&
                             tpagb_norm_type0,add_agb_dust_model0,agb_dust,&
-                            redgb,masscut,fcstar,evtype,smooth_lsf0)
+                            redgb,agb,masscut,fcstar,evtype,smooth_lsf0)
  
     ! Set the parameters that affect the SSP computation.
 
@@ -55,7 +55,7 @@ contains
     double precision, intent(in) :: imf_upper_limit0, imf_lower_limit0,&
                                     imf1,imf2,imf3,vdmc,mdave,dell,&
                                     delt,sbss,fbhb,pagb,agb_dust,&
-                                    redgb,masscut,fcstar,evtype
+                                    redgb,agb,masscut,fcstar,evtype
 
     imf_type=imf_type0
     imf_upper_limit=imf_upper_limit0
@@ -76,6 +76,7 @@ contains
     pset%pagb=pagb
     pset%agb_dust=agb_dust 
     pset%redgb=redgb
+    pset%agb=agb
     pset%masscut=masscut
     pset%fcstar=fcstar
     pset%evtype=evtype

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -835,7 +835,8 @@ class StellarPopulation(object):
         piecewise linearly interpolated.
 
         :param age:
-            Age in Gyr.  ndarray of shape (ntab,)
+            Time since the beginning of the universe in Gyr.  Must be
+            increasing.  ndarray of shape (ntab,)
 
         :param sfr:
             The SFR at each ``age``, in Msun/yr.  Must be an ndarray same
@@ -846,7 +847,8 @@ class StellarPopulation(object):
             (e.g. Z=0.019 for solar with the Padova isochrones and MILES
             stellar library).
         """
-        assert len(age) == len(sfr)
+        assert len(age) == len(sfr), "age and sfr have different size."
+        assert np.all(age[1:] > age[:-1]), "Ages must be increasing."
         ntab = len(age)
         if Z is None:
             Z = np.zeros(ntab)

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -142,6 +142,10 @@ class StellarPopulation(object):
     :param redgb: (default: 1.0)
         Modify weight given to RGB.  Only available with BaSTI isochrone set.
 
+    :param agb: (default: 1.0)
+        Modify weight given to TP-AGB.  This only has effect for FSPS v3.1 or
+        higher.
+
     :param fcstar: (default: 1.0)
         Fraction of stars that the Padova isochrones identify as Carbon stars
         that FSPS assigns to a Carbon star spectrum. Set this to 0.0 if for
@@ -444,6 +448,7 @@ class StellarPopulation(object):
             dell=0.0,
             delt=0.0,
             redgb=1.0,
+            agb=1.0,
             fcstar=1.0,
             fbhb=0.0,
             sbss=0.0,
@@ -1140,8 +1145,8 @@ class ParameterSet(object):
                   "imf1", "imf2", "imf3", "vdmc", "mdave",
                   "dell", "delt", "sbss", "fbhb", "pagb",
                   "add_stellar_remnants", "tpagb_norm_type",
-                  "add_agb_dust_model", "agb_dust", "redgb", "masscut",
-                  "fcstar", "evtype", "smooth_lsf"]
+                  "add_agb_dust_model", "agb_dust", "redgb", "agb",
+                  "masscut", "fcstar", "evtype", "smooth_lsf"]
 
     csp_params = ["smooth_velocity", "redshift_colors",
                   "compute_light_ages","nebemlineinspec",


### PR DESCRIPTION
This PR adds access to the `agb` parameter for controlling the weight of the AGB phase.  For this to work properly you must use FSPS v3.1.  This PR also adds some input checks in `set_tabular_sfh`, improves some docstrings, and changes the `sfr_avg` method to be a more clear and robust to different situations.
