### PR TITLE
Simplify installation procedure, use pygit2 so we don't depend on a runtime git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
     - source activate test
 
     # Python FSPS
-    - python setup.py develop
+    - python -m pip install -e .
 
 before_script: |
     if [[ "$BUILD_DOCS" = "true" && "$TRAVIS_BRANCH" = "master" && -n "$GITHUB_API_KEY" ]]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ You can do this by cloning the `python-fsps repository
 
     git clone https://github.com/dfm/python-fsps.git
     cd python-fsps
-    python setup.py install
+    python -m pip install .
 
 Installing stable version
 -------------------------

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -4,33 +4,35 @@
 from __future__ import division, print_function
 
 import os
-import pygit2
 
 __version__ = "0.3.1"
 
-# Check to make sure that the required environment variable is present.
-try:
-    sps_home = os.environ["SPS_HOME"]
-except KeyError:
-    raise ImportError("You need to have the SPS_HOME environment variable")
+def check_fsps_version():
+    import pygit2
 
-# Check the git history to make sure the required FSPS updates are present
-REQUIRED_GITHASH = 'eb4341d'
+    # Check to make sure that the required environment variable is present.
+    try:
+        sps_home = os.environ["SPS_HOME"]
+    except KeyError:
+        raise ImportError("You need to have the SPS_HOME environment variable")
 
-try:
-    fsps_repo = pygit2.Repository(sps_home)
-except pygit2.GitError:
-    raise ImportError("Your SPS_HOME does not point to a repository under git version "
-                      "control. FSPS is available on github at "
-                      "https://github.com/cconroy20/fsps and should be cloned from there")
+    # Check the git history to make sure the required FSPS updates are present
+    REQUIRED_GITHASH = 'eb4341d'
 
-accepted = any(REQUIRED_GITHASH == commit.short_id
-        for commit in fsps_repo.walk(fsps_repo.head.target))
-if not accepted:
-    raise ImportError("Your FSPS version does not have correct history. "
-                      "Perhaps you need to pull the most up-to-date FSPS version. "
-                      "Please make sure that you have the following commit "
-                      "in your git history: {0}".format(REQUIRED_GITHASH))
+    try:
+        fsps_repo = pygit2.Repository(sps_home)
+    except pygit2.GitError:
+        raise ImportError("Your SPS_HOME does not point to a repository under git version "
+                          "control. FSPS is available on github at "
+                          "https://github.com/cconroy20/fsps and should be cloned from there")
+
+    accepted = any(REQUIRED_GITHASH == commit.short_id
+            for commit in fsps_repo.walk(fsps_repo.head.target))
+    if not accepted:
+        raise ImportError("Your FSPS version does not have correct history. "
+                          "Perhaps you need to pull the most up-to-date FSPS version. "
+                          "Please make sure that you have the following commit "
+                          "in your git history: {0}".format(REQUIRED_GITHASH))
 
 # Only import the module if not run from the setup script.
 try:
@@ -38,6 +40,7 @@ try:
 except NameError:
     __FSPS_SETUP__ = False
 if not __FSPS_SETUP__:
+    check_fsps_version()
     __all__ = ["StellarPopulation", "find_filter", "get_filter",
                "list_filters"]
     from .fsps import StellarPopulation

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -4,52 +4,33 @@
 from __future__ import division, print_function
 
 import os
-import subprocess
+import pygit2
 
-__version__ = "0.3.0"
-
-def run_command(cmd):
-    """
-    Open a child process, and return its exit status and stdout.
-
-    """
-    child = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE,
-                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    out = [s.decode("utf-8").strip() for s in child.stdout]
-    err = [s.decode("utf-8").strip() for s in child.stderr]
-    w = child.wait()
-    return os.WEXITSTATUS(w), out, err
-
+__version__ = "0.3.1"
 
 # Check to make sure that the required environment variable is present.
 try:
-    ev = os.environ["SPS_HOME"]
+    sps_home = os.environ["SPS_HOME"]
 except KeyError:
     raise ImportError("You need to have the SPS_HOME environment variable")
 
-# Check the githashes to make sure the required FSPS updates are
-# present, and if not or there are no githashes, raise an error
-REQUIRED_GITHASHES = ['6ad1058', 'b5250ab', 'a23e409', '45f9680','05584df']
+# Check the git history to make sure the required FSPS updates are present
+REQUIRED_GITHASH = 'eb4341d'
 
-cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
-stat, githashes, err = run_command(cmd)
-accepted = (len(githashes) > 0) and (len(err) == 0)
-if not accepted:
-    raise ImportError("Your FSPS version does not seem to be under git version "
+try:
+    fsps_repo = pygit2.Repository(sps_home)
+except pygit2.GitError:
+    raise ImportError("Your SPS_HOME does not point to a repository under git version "
                       "control. FSPS is available on github at "
                       "https://github.com/cconroy20/fsps and should be cloned from there")
-accepted = [req in githashes for req in REQUIRED_GITHASHES]
-if False in accepted:
-    reqs = ",".join([r[:-2] for r in REQUIRED_GITHASHES])
-    raise ImportError("Your FSPS version does not have correct history.  "
+
+accepted = any(REQUIRED_GITHASH == commit.short_id
+        for commit in fsps_repo.walk(fsps_repo.head.target))
+if not accepted:
+    raise ImportError("Your FSPS version does not have correct history. "
                       "Perhaps you need to pull the most up-to-date FSPS version. "
-                      "Please make sure that you have the following commits "
-                      "in your git history, preferably with the last listed commit "
-                      "the same as your current FSPS commit githash: {0}".format(reqs))
-else:
-    # Store the githash.  If any version checking is going to happen,
-    # it should happen here
-    fsps_vers = githashes[0]
+                      "Please make sure that you have the following commit "
+                      "in your git history: {0}".format(REQUIRED_GITHASH))
 
 # Only import the module if not run from the setup script.
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+pygit2

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
     install_requires=[
         'numpy<=1.16; python_version=="2.7"',
         'numpy; python_version>="3.5"',
-        'pygit2',
+        'pygit2<=0.28; python_version=="2.7"',
+        'pygit2; python_version>="3.5"',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ def is_fortran_program(path):
 class build_fsps(build_ext):
 
     def run(self):
+        from fsps import check_fsps_version
+        check_fsps_version()
+
         # Generate the Fortran signature/interface.
         files = ['fsps.f90']
         flags = "-m _fsps -h fsps.pyf --overwrite-signature".split()

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
-    setup_requires=[
+    install_requires=[
         'numpy==1.16; python_version=="2.7"',
         'numpy; python_version>="3.5"',
         'pygit2',

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=[
-        'numpy==1.16; python_version=="2.7"',
+        'numpy<=1.16; python_version=="2.7"',
         'numpy; python_version>="3.5"',
         'pygit2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -120,4 +120,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
+    setup_requires=[
+        'numpy==1.16; python_version=="2.7"',
+        'numpy; python_version>="3.5"',
+    ],
 )


### PR DESCRIPTION
These changes should make it much easier for newcomers to install and use python-fsps. It obviates any need for editing the FSPS Makefile and prevents mysterious crashes if python-fsps can't find a git executable at runtime.

While the FSPS Makefile does now support parallel compilation (`make -j`), I've already run into build failures due to HPC filesystem inconsistency (gfortran says a `.mod` file is missing when it was definitely just generated) while working on this patch as a result of using `make -j`, so I don't use it here.