### PR TITLE
copy self.wavelengths before returning

### DIFF
--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -581,7 +581,7 @@ class StellarPopulation(object):
         if self.params.dirty:
             self._compute_csp()
 
-        wavegrid = self.wavelengths.copy()
+        wavegrid = self.wavelengths
         if peraa:
             factor = 3e18 / wavegrid ** 2
 

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -581,7 +581,7 @@ class StellarPopulation(object):
         if self.params.dirty:
             self._compute_csp()
 
-        wavegrid = self.wavelengths
+        wavegrid = self.wavelengths.copy()
         if peraa:
             factor = 3e18 / wavegrid ** 2
 

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -990,7 +990,7 @@ class StellarPopulation(object):
         if self._wavelengths is None:
             NSPEC = driver.get_nspec()
             self._wavelengths = driver.get_lambda(NSPEC)
-        return self._wavelengths
+        return self._wavelengths.copy()
 
     @property
     def emline_wavelengths(self):
@@ -999,7 +999,7 @@ class StellarPopulation(object):
         if self._emwavelengths is None:
             NLINE = driver.get_nemline()
             self._emwavelengths = driver.get_emlambda(NLINE)
-        return self._emwavelengths
+        return self._emwavelengths.copy()
 
     @property
     def zlegend(self):


### PR DESCRIPTION
The StellarPopulation.get_spectrum method will now return a copy of self.wavelengths so that it is not modified (e.g. in case the spectrum is shifted from rest-frame with 'wavelengths *= 1+z')