### PR TITLE
Add flexible output units on 'StellarPopulation.get_mags'.

### DIFF
--- a/fsps/fsps.f90
+++ b/fsps/fsps.f90
@@ -346,6 +346,24 @@ contains
 
   end subroutine
 
+  subroutine smooth_spectrum_ires(ns,wave,spec,sigma_wave,minw,maxw)
+    
+    ! Smooth the spectrum by a wavelength-dependent gaussian of width sigma_broad
+    
+    implicit none
+    integer, intent(in) :: ns
+    double precision :: dummy_sigma
+    double precision, intent(in) :: minw,maxw
+    double precision, dimension(ns), intent(in) :: wave
+    double precision, dimension(ns), intent(in) :: sigma_wave
+    double precision, dimension(ns), intent(inout) :: spec
+    
+    dummy_sigma = 100.
+    
+    call smoothspec(wave,spec,dummy_sigma,minw,maxw,sigma_wave)
+
+  end subroutine
+
   subroutine stellar_spectrum(ns,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec_out)
     
     ! Get a stellar spectrum for a given set of parameters
@@ -467,7 +485,7 @@ contains
     ns = nspec
 
   end subroutine
-
+  
   subroutine get_nbands(nb)
 
     ! Get the number of known filters (hard coded in sps_vars).

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -621,12 +621,14 @@ class StellarPopulation(object):
             magnitude for. This should correspond to the result of
             :func:`fsps.find_filter`.
             
-        :param units: ('abmag', 'ujy', 'njy', 'flam'; default: 'abmag')
-            If other than 'abmag', convert to linear flux densities:
+        :param units: (default: 'abmag')
+            Output units.  Available options:
+                'abmag', 'vegamag': Magnitudes
                 'ujy': f-nu, micro-Jansky
                 'njy': f-nu, nano-Jansky
+                'fnu': f-nu, erg/s/cm**2/Hz
                 'flam': f-lambda, erg/s/cm**2/A
-
+            
         :param stellar_mass: (float, default: None)
             Optionally scale the output to a defined stellar mass.
             
@@ -1210,7 +1212,11 @@ class StellarPopulation(object):
         
         :param attach_units: (default: True)
             Try to attach unit label using `~astropy.units`.
-                      
+        
+        :returns scaled_mags:
+            Magnitudes / flux densities scaled by `scale` and in the desired
+            `units`.
+                       
         """
         try:
             import astropy.units as u

--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -904,7 +904,9 @@ class StellarPopulation(object):
             assert self._zcontinuous == 3, "_zcontinuous must be 3 for multi-Z tabular."
             assert self.params["add_neb_emission"] is False, ("Cannot compute nebular emission "
                                                               "with multi-metallicity tabular SFH.")
-
+        
+        self._sfh_tab = (age, sfr, Z)
+        
         driver.set_sfh_tab(age*1e9, sfr, Z)
         if self.params["sfh"] == 3:
             self.params.dirtiness = max(1, self.params.dirtiness)
@@ -1227,12 +1229,12 @@ class StellarPopulation(object):
         
         dmag = -2.5*np.log10(scale)
         mags2 = np.atleast_2d(mags)
-        if hasattr(mags, 'ndim'):
-            if mags.ndim == 1:
-                mags2 = mags2.T
-        
-        if isinstance(mags, list):
-            mags2 = mags2.T
+        # if hasattr(mags, 'ndim'):
+        #     if mags.ndim == 1:
+        #         mags2 = mags2.T
+        # 
+        # if isinstance(mags, list):
+        #     mags2 = mags2.T
         
         # Allow for vector scale
         scaled_mags = (np.atleast_2d(mags2).T+dmag).T

--- a/fsps/tests.py
+++ b/fsps/tests.py
@@ -53,7 +53,8 @@ def test_get_mags():
 
 def test_convert_mags():
     from .filters import FILTERS
-    from .fsps import LIGHTSPEEED
+    
+    LIGHTSPEED = 2.99792458e+18
     
     # Magnitudes in same system, no correction
     vega = StellarPopulation.convert_mags(0, units='vegamag', scale=1.,


### PR DESCRIPTION
I added a`StellarPopulation.convert_mags` method that allows you to both switch between AB/Vega magnitude systems and/or retrieve linear flux densities at runtime with the `StellarPopulation.get_mags` method.   It's implemented as a `@staticmethod` on `StellarPopulation` 1) so that it can be used without compiling the FSPS driver and 2) so that it doesn't pollute the `fsps` module namespace.

There's also a somewhat awkward `match_dimensions` private function in `fsps.fsps.py` that is used to match the data type / dimensions of the input and output data of `convert_mags`, allowing for scalar, `list` and `ndarray` inputs.