### PR TITLE
Add directory check for SPS_HOME

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -29,7 +29,7 @@ except KeyError:
 
 # Check to make sure the required environment variable is an FSPS install directory
 if not os.path.isdir(ev):
-    raise ImportError(f"SPS_HOME environment variable '{ev}' is not a directory - is it set correctly?")
+    raise ImportError("SPS_HOME environment variable '" + ev + "' is not a directory - is it set correctly?")
 
 # Check the githashes to make sure the required FSPS updates are
 # present, and if not or there are no githashes, raise an error

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -29,7 +29,7 @@ except KeyError:
 
 # Check to make sure the required environment variable is an FSPS install directory
 if not os.path.isdir(ev):
-    raise ImportError(f"SPS_HOME environment variable "{ev}" is not a directory - is it set correctly?')
+    raise ImportError(f"SPS_HOME environment variable '{ev}' is not a directory - is it set correctly?")
 
 # Check the githashes to make sure the required FSPS updates are
 # present, and if not or there are no githashes, raise an error

--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -27,6 +27,10 @@ try:
 except KeyError:
     raise ImportError("You need to have the SPS_HOME environment variable")
 
+# Check to make sure the required environment variable is an FSPS install directory
+if not os.path.isdir(ev):
+    raise ImportError(f"SPS_HOME environment variable "{ev}" is not a directory - is it set correctly?')
+
 # Check the githashes to make sure the required FSPS updates are
 # present, and if not or there are no githashes, raise an error
 REQUIRED_GITHASHES = ['6ad1058', 'b5250ab', 'a23e409', '45f9680','05584df']


### PR DESCRIPTION
Hi,

On a fresh install, I made a typo in the SPS_HOME variable. This caused python-fsps to throw the 'FSPS not under git control' error. For this case, that error was maybe not ideal, because FSPS was under git control - it just wasn't correctly referenced. To catch similar mistakes, can I suggest adding the FSPS directory check below?

One could extend this to check the directory does actually contain FSPS, perhaps by checking the first line of the readme, but I'm not sure that's warranted.