### PR TITLE
Edited dust1_index docstring to reflect usage

### DIFF
--- a/fsps/fsps.py
+++ b/fsps/fsps.py
@@ -366,7 +366,7 @@ class StellarPopulation(object):
 
     :param dust1_index: (default: -1.0)
         Power law index of the attenuation curve affecting stars younger than
-        dust_tesc corresponding to ``dust1``. Only used when ``dust_type=0``.
+        dust_tesc corresponding to ``dust1``. Used for all dust types.
 
     :param mwr: (default: 3.1)
         The ratio of total to selective absorption which characterizes the MW


### PR DESCRIPTION
Previously, the docstring (and therefore documentation on the
website) stated that dust1_index is only used when dust_type=0.
This is not the case, dust1_index is used for all dust types,
as can be seen in the Fortran FSPS documentation. I have also
verified this in in python-fsps. This commit changes the docstring
to correct this.