### PR TITLE
make python-fsps compile on windows

### DIFF
--- a/fsps/__init__.py
+++ b/fsps/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import division, print_function
 
 import os
+import sys
 import subprocess
 
 __version__ = "0.3.0"
@@ -18,8 +19,10 @@ def run_command(cmd):
     out = [s.decode("utf-8").strip() for s in child.stdout]
     err = [s.decode("utf-8").strip() for s in child.stderr]
     w = child.wait()
-    return os.WEXITSTATUS(w), out, err
-
+    if not sys.platform.startswith("win"):
+        return os.WEXITSTATUS(w), out, err
+    else:
+        return w, out, err
 
 # Check to make sure that the required environment variable is present.
 try:
@@ -31,7 +34,7 @@ except KeyError:
 # present, and if not or there are no githashes, raise an error
 REQUIRED_GITHASHES = ['6ad1058', 'b5250ab', 'a23e409', '45f9680','05584df']
 
-cmd = 'cd {0}; git log --format="format:%h"'.format(ev)
+cmd = 'cd {0}; git log --format="format:%h"'.format(ev) if not sys.platform.startswith("win") else 'cd {0} & git log --format="format:%h"'.format(ev)
 stat, githashes, err = run_command(cmd)
 accepted = (len(githashes) > 0) and (len(err) == 0)
 if not accepted:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ class build_fsps(build_ext):
 
         # Compile the library.
         flags = '-c -I{0} --f90flags=-cpp --f90flags=-fPIC'.format(fsps_dir)
+        if sys.platform.startswith("win"):
+            flags += " --compiler=mingw32"
         flags = flags.split()
         print("Running f2py on {0} with flags {1}".format(fns, flags))
         invoke_f2py(fns, flags, wd='fsps')


### PR DESCRIPTION
This PR enable `python-fsps` to be compiled on Windows.

`python-fsps` and `fsps` seems to be working fine on my Windows 10 20H2 x64 with conda python 3.8.

Fixing issue #76 and issue #132