### PR TITLE
Update filters.py to correct an error that last filter is not loaded.

### DIFF
--- a/fsps/filters.py
+++ b/fsps/filters.py
@@ -125,6 +125,7 @@ class Filter(object):
                         trans.append(float(t))
                     except(ValueError):
                         pass
+        TRANS_CACHE[names[filter_index]] = (np.array(lambdas), np.array(trans))
 
 def _load_filter_dict():
     """


### PR DESCRIPTION
It is apparently the last filter is not saved in the `TRANS_CACHE`

Here is the error:

```
------------------------------------------

In [1]: import fsps

In [2]: band = fsps.filters.get_filter('ps1_y')

In [3]: band.transmission
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/.local/lib/python3.8/site-packages/fsps/filters.py in transmission(self)
     85         try:
---> 86             return TRANS_CACHE[self.name]
     87         except KeyError as e:

KeyError: 'ps1_y'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-3-1b84cc3a2592> in <module>
----> 1 band.transmission

~/.local/lib/python3.8/site-packages/fsps/filters.py in transmission(self)
     86             return TRANS_CACHE[self.name]
     87         except KeyError as e:
---> 88             e.args += ("Could not find transmission data "
     89                        "for {0}".format(self.name))
     90             raise

TypeError: can only concatenate tuple (not "str") to tuple
```