### PR TITLE
Move parameter check

### DIFF
--- a/src/fsps/fsps.py
+++ b/src/fsps/fsps.py
@@ -544,6 +544,7 @@ class StellarPopulation(object):
         self._libraries = None
 
     def _update_params(self):
+        self.params.check_params()
         if self.params.dirtiness == 2:
             driver.set_ssp_params(*[self.params[k] for k in self.params.ssp_params])
         if self.params.dirtiness >= 1:
@@ -1334,4 +1335,3 @@ class ParameterSet(object):
                 self.dirtiness = max(1, self.dirtiness)
 
             self._params[k] = v
-            self.check_params()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -61,6 +61,32 @@ def test_libraries(pop_and_params):
     assert dlib == pop.duste_library
 
 
+def test_param_checks(pop_and_params):
+    pop, params = pop_and_params
+    _reset_default_params(pop, params)
+    pop.params["sfh"] = 1
+    pop.params["tage"] = 2
+    pop.params["sf_start"] = 0.5
+    # this should never raise an error:
+    w, s = pop.get_spectrum(tage=pop.params["tage"])
+    # this used to raise an assertion error in the setter:
+    pop.params["sf_start"] = 2.1
+    # this also used to raise an assertion error in the setter:
+    pop.params["imf_type"] = 8
+    # fix the IMF issue but leave the sf_start error
+    pop.params["imf_type"] = 1
+    try:
+        # This *should* still raise an AssertionError
+        w, s = pop.get_spectrum(tage=pop.params["tage"])
+        # Hacky way to make sure the AssertionError still got thrown
+        raise ValueError("Did not throw exception for invalid sf_start > tage")
+    except(AssertionError):
+        pass
+    pop.params["tage"] = 1.0
+    pop.params["sf_start"] = 0.1
+    w, s = pop.get_spectrum(tage=pop.params["tage"])
+
+
 def test_filters():
     """Test all the filters got transmission data loaded."""
     flist = filters.list_filters()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -70,10 +70,10 @@ def test_param_checks(pop_and_params):
     # this should never raise an error:
     w, s = pop.get_spectrum(tage=pop.params["tage"])
     # this used to raise an assertion error in the setter:
-    pop.params["sf_start"] = 2.1
+    pop.params["sf_start"] = pop.params["tage"] + 0.1
     # this also used to raise an assertion error in the setter:
     pop.params["imf_type"] = 8
-    # fix the IMF issue but leave the sf_start error
+    # fix the invalid IMF but leave the invalid sf_start > tage
     pop.params["imf_type"] = 1
     try:
         # This *should* still raise an AssertionError
@@ -99,10 +99,11 @@ def test_filters():
 def test_get_mags(pop_and_params):
     """Basic test for supplying filter names to get_mags"""
     pop, params = pop_and_params
+    _reset_default_params(pop, params)
     fuv1 = pop.get_mags(bands=["galex_fuv"])[:, 0]
     mags = pop.get_mags()
-    fuv2 = mags[:, 61]
-    fuv3 = mags[:, 62]
+    fuv2 = mags[:, 61]  # this should be galex_FUV
+    fuv3 = mags[:, 62]  # this should *not* be galex_FUV
     assert np.all(fuv1 == fuv2)
     assert np.all(fuv1 != fuv3)
 


### PR DESCRIPTION
This moves the parameter validity check from the parameter value setter to the place where the parameters are actually passed to the fortran driver (`StellarPopulation._update_parameters()`). This gives less instant feedback if you give an invalid parameter, but should solve the issue in #183

Also added a test, with a clunky way to check that an assertion error is raised appropriately without completely rewriting the test infrastructure.