### PR TITLE
Access more FSPS quantities as attributes

### DIFF
--- a/src/fsps/fsps.f90
+++ b/src/fsps/fsps.f90
@@ -366,6 +366,17 @@ contains
 
   end subroutine
 
+  subroutine get_ssp_weights(n_age, n_z, ssp_wghts_out)
+
+    ! Return the weights of each SSP in the CSP
+
+    implicit none
+    integer, intent(in) :: n_age,n_z
+    double precision, dimension(n_age,n_z), intent(inout) :: ssp_wghts_out
+    ssp_wghts_out = weight_ssp
+
+  end subroutine
+
   subroutine get_ssp_spec(ns,n_age,n_z,ssp_spec_out,ssp_mass_out,ssp_lbol_out)
 
     ! Return the contents of the ssp spectral array,
@@ -400,7 +411,7 @@ contains
     sfh_tab(2, 1:ntabsfh) = sfr
     sfh_tab(3, 1:ntabsfh) = met
 
-  end subroutine set_sfh_tab
+  end subroutine
 
   subroutine set_ssp_lsf(nsv, sigma, wlo, whi)
 
@@ -414,7 +425,7 @@ contains
     lsfinfo%maxlam = whi
     lsfinfo%lsf = sigma
 
-  end subroutine set_ssp_lsf
+  end subroutine
 
   subroutine get_setup_vars(cvms, vta_flag)
 
@@ -531,7 +542,7 @@ contains
 
   subroutine get_res(ns,res)
 
-    ! Get the grid of wavelength bins.
+    ! Get the resolution array of the spectral library
     implicit none
     integer, intent(in) :: ns
     double precision, dimension(ns), intent(out) :: res

--- a/src/fsps/fsps.f90
+++ b/src/fsps/fsps.f90
@@ -529,6 +529,16 @@ contains
 
   end subroutine
 
+  subroutine get_res(ns,res)
+
+    ! Get the grid of wavelength bins.
+    implicit none
+    integer, intent(in) :: ns
+    double precision, dimension(ns), intent(out) :: res
+    res = spec_res
+
+  end subroutine
+
   subroutine get_libraries(isocname,specname,dustname)
 
     implicit none

--- a/src/fsps/fsps.py
+++ b/src/fsps/fsps.py
@@ -767,6 +767,21 @@ class StellarPopulation(object):
 
         return spec, mass, lbol
 
+    def _ssp_weights(self):
+         """Get the weights of the SSPs for the CSP
+
+         :returns weights:
+             The weights ``w`` of each SSP s.t. the total spectrum is the sum
+             :math:`L_{\lambda} = \sum_i,j w_i,j \, S_{i,j,\lambda}` where
+             math:`i,j` run over age and metallicity.
+         """
+
+         NTFULL = driver.get_ntfull()
+         NZ = driver.get_nz()
+         weights = np.zeros([NTFULL, NZ], order="F")
+         driver.get_ssp_weights(weights)
+         return weights
+
     def _get_stellar_spectrum(
         self,
         mact,

--- a/src/fsps/fsps.py
+++ b/src/fsps/fsps.py
@@ -1050,7 +1050,9 @@ class StellarPopulation(object):
 
     @property
     def resolutions(self):
-        r"""The resolution array (units)"""
+        r"""The resolution array, in km/s dispersion. Negative numbers indicate
+         poorly defined, approximate, resolution (based on coarse opacity
+         binning in theoretical spectra)"""
         if self._resolutions is None:
             NSPEC = driver.get_nspec()
             self._resolutions = driver.get_res(NSPEC)

--- a/src/fsps/fsps.py
+++ b/src/fsps/fsps.py
@@ -534,6 +534,7 @@ class StellarPopulation(object):
         self._zcontinuous = zcontinuous
         # Caching.
         self._wavelengths = None
+        self._resolutions = None
         self._emwavelengths = None
         self._zlegend = None
         self._solar_metallicity = None
@@ -1031,6 +1032,14 @@ class StellarPopulation(object):
             NSPEC = driver.get_nspec()
             self._wavelengths = driver.get_lambda(NSPEC)
         return self._wavelengths.copy()
+
+    @property
+    def resolutions(self):
+        r"""The resolution array (units)"""
+        if self._resolutions is None:
+            NSPEC = driver.get_nspec()
+            self._resolutions = driver.get_res(NSPEC)
+        return self._resolutions.copy()
 
     @property
     def emline_wavelengths(self):


### PR DESCRIPTION
This PR adds access to several newish FSPS quantities that may be of relevance.  There is a resolution array for each stellar library, and there is now access to the SSP weights for the last computed stellar population.  Also added a test for the SSP weights, and reordered tests to try and take better advantage of SSP caching.