### PR TITLE
Test/build against Python 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "macos-latest"
+          - "macos-14"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,10 +35,10 @@ jobs:
           fetch-depth: 0
       - name: Set up macOS
         run: echo "FC=gfortran-13" >> "$GITHUB_ENV"
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-14' }}
       - uses: pypa/cibuildwheel@v3.4.0
         env:
-          MACOSX_DEPLOYMENT_TARGET: "15.0"
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
       - uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         os: [ubuntu-latest]
         with-options: [false]
         include:
           - os: macos-14
-            python-version: "3.12"
+            python-version: "3.13"
             with-options: false
           - os: ubuntu-latest
             python-version: "3.11"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,13 @@ submodules:
   include: all
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   apt_packages:
     - gcc
     - g++
     - gfortran
   tools:
-    python: "3.10"
+    python: "3.14"
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ requires = ["scikit-build-core", "numpy"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-ninja.minimum-version = "1.10"
-cmake.minimum-version = "3.17.2"
+ninja.version = ">=1.10"
+cmake.version = ">=3.17.2"
 sdist.exclude = ["src/fsps/libfsps"]
 sdist.include = [
     "src/fsps/libfsps/src/*.f90",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ sdist.include = [
     "src/fsps/libfsps/README",
     "src/fsps/fsps_version.py",
 ]
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 write_to = "src/fsps/fsps_version.py"


### PR DESCRIPTION
Bump the test matrix to cover Python 3.14 (and shift the macOS include to 3.13), and update the scikit-build-core config to the non-deprecated `cmake.version`/`ninja.version` keys, which are required by `scikit-build-core >= 0.8` to build wheels at all.